### PR TITLE
Fixed Issue #49 : Text covering a multiline

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
@@ -107,6 +107,8 @@ public class MainActivity extends AppCompatActivity {
         else{
             etMessage.setImeOptions(EditorInfo.IME_FLAG_NO_ENTER_ACTION);
             etMessage.setSingleLine(false);
+            etMessage.setMaxLines(4);
+            etMessage.setVerticalScrollBarEnabled(true);
         }
     }
 


### PR DESCRIPTION
If user were writing multiple line message then edittext was covering
the large portion of UI. Now it covers 4 lines max.