### PR TITLE
fixes #182 SignUp screen after sign up is sucessfull , snackbar added

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/activities/SignUpActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/SignUpActivity.java
@@ -2,7 +2,9 @@ package org.fossasia.susi.ai.activities;
 
 import android.app.ProgressDialog;
 import android.content.DialogInterface;
+import android.content.Intent;
 import android.os.Bundle;
+import android.support.design.widget.Snackbar;
 import android.support.design.widget.TextInputLayout;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
@@ -100,28 +102,33 @@ public class SignUpActivity extends AppCompatActivity {
                 signUp.setEnabled(true);
             }
         });
+
         signUpCall.enqueue(new Callback<SignUpResponse>() {
             @Override
             public void onResponse(Call<SignUpResponse> call, Response<SignUpResponse> response) {
                 if (response.isSuccessful() && response.body() != null) {
                     Toast.makeText(SignUpActivity.this, response.body().getMessage(), Toast.LENGTH_SHORT).show();
+                    Intent intent = new Intent(SignUpActivity.this, LoginActivity.class);
+                    intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_NEW_TASK);
+                    startActivity(intent);
+                    finish();
                 } else
-                    Toast.makeText(SignUpActivity.this, response.message(), Toast.LENGTH_SHORT).show();
+                    Snackbar.make(findViewById(R.id.activity_sign_up), response.message(), Snackbar.LENGTH_LONG).show();
                 signUp.setEnabled(true);
                 progressDialog.dismiss();
                 CredentialHelper.clearFields(email, password, confirmPassword);
-                finish();
             }
 
             @Override
             public void onFailure(Call<SignUpResponse> call, Throwable t) {
                 t.printStackTrace();
-                Toast.makeText(SignUpActivity.this, "Please check your internet.", Toast.LENGTH_SHORT).show();
+                Snackbar.make(findViewById(R.id.activity_sign_up), "Please check your internet.", Snackbar.LENGTH_LONG).show();
                 signUp.setEnabled(true);
                 progressDialog.dismiss();
             }
         });
     }
+
 
 
 }


### PR DESCRIPTION
Fixes issue #182 

Changes: now after successful sign up screen is directed to login screen. Snackbar shows instead of Toast message in case of error.



