### PR TITLE
Fix #222 highlighting search result in map and link message

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/adapters/recyclerAdapters/ChatFeedRecyclerAdapter.java
+++ b/app/src/main/java/org/fossasia/susi/ai/adapters/recyclerAdapters/ChatFeedRecyclerAdapter.java
@@ -446,6 +446,21 @@ public class ChatFeedRecyclerAdapter extends RealmRecyclerViewAdapter<ChatMessag
                         }
                     }
                 });
+
+                if(highlightMessagePosition==position)
+                {
+                    String text = mapViewHolder.text.getText().toString();
+                    SpannableString modify = new SpannableString(text);
+                    Pattern pattern = Pattern.compile(query, Pattern.CASE_INSENSITIVE);
+                    Matcher matcher = pattern.matcher(modify);
+                    while (matcher.find()) {
+                        int startIndex = matcher.start();
+                        int endIndex = matcher.end();
+                        modify.setSpan(new BackgroundColorSpan(Color.parseColor("#2b3c4e")), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+                    }
+                    mapViewHolder.text.setText(modify);
+                }
+
             } catch (Exception e) {
                 e.printStackTrace();
             }
@@ -508,6 +523,20 @@ public class ChatFeedRecyclerAdapter extends RealmRecyclerViewAdapter<ChatMessag
 
             }
         };
+
+        if(highlightMessagePosition==position)
+        {
+            String text = linkPreviewViewHolder.text.getText().toString();
+            SpannableString modify = new SpannableString(text);
+            Pattern pattern = Pattern.compile(query, Pattern.CASE_INSENSITIVE);
+            Matcher matcher = pattern.matcher(modify);
+            while (matcher.find()) {
+                int startIndex = matcher.start();
+                int endIndex = matcher.end();
+                modify.setSpan(new BackgroundColorSpan(Color.parseColor("#2b3c4e")), startIndex, endIndex, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+            }
+            linkPreviewViewHolder.text.setText(modify);
+        }
 
         if (model != null) {
 


### PR DESCRIPTION
Fixes issue #222 

Changes: search query is highlighted in messages with map and link.

Screenshots for the change: 
![1](https://cloud.githubusercontent.com/assets/12713808/19419546/857f13ce-93f7-11e6-8e5b-f25cccb66e2c.png)
![2](https://cloud.githubusercontent.com/assets/12713808/19419547/8589dc3c-93f7-11e6-9709-b46adc2a60a0.png)



