### PR TITLE
Fixes #191: Copy and Delete feature in Link Messages is not working

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/adapters/recyclerAdapters/ChatFeedRecyclerAdapter.java
+++ b/app/src/main/java/org/fossasia/susi/ai/adapters/recyclerAdapters/ChatFeedRecyclerAdapter.java
@@ -323,6 +323,7 @@ public class ChatFeedRecyclerAdapter extends RealmRecyclerViewAdapter<ChatMessag
                                                         break;
                                                     case 1:
                                                         deleteMessage(position);
+                                                        Snackbar.make(view, "Deleted", Snackbar.LENGTH_LONG).show();
                                                         break;
 
                                                 }
@@ -412,6 +413,7 @@ public class ChatFeedRecyclerAdapter extends RealmRecyclerViewAdapter<ChatMessag
                                         break;
                                     case 1:
                                         deleteMessage(position);
+                                        Snackbar.make(view, "Deleted", Snackbar.LENGTH_LONG).show();
                                         break;
 
                                 }
@@ -480,6 +482,36 @@ public class ChatFeedRecyclerAdapter extends RealmRecyclerViewAdapter<ChatMessag
         final ChatMessage model = getData().get(position);
         linkPreviewViewHolder.text.setText(model.getContent());
         linkPreviewViewHolder.timestampTextView.setText(model.getTimeStamp());
+        linkPreviewViewHolder.chatMessageView.setOnLongClickListener(new View.OnLongClickListener() {
+            @Override
+            public boolean onLongClick(final View view) {
+
+                AlertDialog.Builder builder = new AlertDialog.Builder(currContext);
+                builder.setItems(new CharSequence[]
+                                {" Copy Text", " Delete"},
+                        new DialogInterface.OnClickListener() {
+                            public void onClick(DialogInterface dialog, int which) {
+                                switch (which) {
+                                    case 0:
+                                        String str = linkPreviewViewHolder.text.getText().toString();
+                                        setClipboard(currContext,str);
+
+                                        Snackbar.make(view, "Copied", Snackbar.LENGTH_LONG).show();
+
+                                        break;
+                                    case 1:
+                                        deleteMessage(position);
+                                        Snackbar.make(view, "Deleted", Snackbar.LENGTH_LONG).show();
+                                        break;
+
+                                }
+                            }
+                        });
+                builder.create().show();
+
+                return false;
+            }
+        });
         LinkPreviewCallback linkPreviewCallback = new LinkPreviewCallback() {
             @Override
             public void onPre() {
@@ -555,6 +587,36 @@ public class ChatFeedRecyclerAdapter extends RealmRecyclerViewAdapter<ChatMessag
         final ChatMessage model = getData().get(position);
         if (model != null) {
             try {
+                pieChartViewHolder.chatMessageView.setOnLongClickListener(new View.OnLongClickListener() {
+                    @Override
+                    public boolean onLongClick(final View view) {
+
+                        AlertDialog.Builder builder = new AlertDialog.Builder(currContext);
+                        builder.setItems(new CharSequence[]
+                                        {" Copy Text", " Delete"},
+                                new DialogInterface.OnClickListener() {
+                                    public void onClick(DialogInterface dialog, int which) {
+                                        switch (which) {
+                                            case 0:
+                                                String str = pieChartViewHolder.chatTextView.getText().toString();
+                                                setClipboard(currContext,str);
+
+                                                Snackbar.make(view, "Copied", Snackbar.LENGTH_LONG).show();
+
+                                                break;
+                                            case 1:
+                                                deleteMessage(position);
+                                                Snackbar.make(view, "Deleted", Snackbar.LENGTH_LONG).show();
+                                                break;
+
+                                        }
+                                    }
+                                });
+                        builder.create().show();
+
+                        return false;
+                    }
+                });
                 pieChartViewHolder.chatTextView.setText(model.getContent());
                 pieChartViewHolder.timeStamp.setText(model.getTimeStamp());
                 pieChartViewHolder.pieChart.setUsePercentValues(true);

--- a/app/src/main/java/org/fossasia/susi/ai/adapters/viewHolders/LinkPreviewViewHolder.java
+++ b/app/src/main/java/org/fossasia/susi/ai/adapters/viewHolders/LinkPreviewViewHolder.java
@@ -10,6 +10,7 @@ import org.fossasia.susi.ai.R;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import me.himanshusoni.chatmessageview.ChatMessageView;
 
 /**
  * Created by better_clever on 12/10/16.
@@ -19,6 +20,8 @@ public class LinkPreviewViewHolder extends RecyclerView.ViewHolder{
 
     @BindView(R.id.text)
     public TextView text;
+    @BindView(R.id.chatMessageView)
+    public ChatMessageView chatMessageView;
     @BindView(R.id.link_preview_image)
     public ImageView previewImageView;
     @BindView(R.id.link_preview_title)

--- a/app/src/main/java/org/fossasia/susi/ai/adapters/viewHolders/PieChartViewHolder.java
+++ b/app/src/main/java/org/fossasia/susi/ai/adapters/viewHolders/PieChartViewHolder.java
@@ -10,9 +10,12 @@ import org.fossasia.susi.ai.R;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
+import me.himanshusoni.chatmessageview.ChatMessageView;
 
 public class PieChartViewHolder extends RecyclerView.ViewHolder {
 
+    @BindView(R.id.chatMessageView)
+    public ChatMessageView chatMessageView;
     @BindView(R.id.text)
     public TextView chatTextView;
     @BindView(R.id.piechart)


### PR DESCRIPTION
Fixes issue #191

Changes: 
Copy and Delete Feature is now working on all types of messages + snackbar is displayed to notify deletion too.

Screenshots for the change: 

Not Applicable.
