### PR TITLE
Fixes #227: Cursor not visible in SendMessageLayout.

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -50,10 +50,11 @@
                 android:layout_marginLeft="10dp"
                 android:layout_marginRight="10dp"
                 android:layout_weight="1"
-                android:background="@android:color/transparent"
                 android:hint="@string/send_msg_hint"
                 android:imeOptions="actionSend"
-                android:inputType="text" />
+                android:inputType="text"
+                android:background="@android:color/transparent"
+                android:theme="@style/sendMessageEditTextTheme"/>
 
 
             <android.support.design.widget.FloatingActionButton
@@ -61,6 +62,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_marginRight="3dp"
+                android:layout_marginEnd="3dp"
                 android:clickable="true"
                 android:src="@drawable/ic_mic_white_24dp"
                 app:backgroundTint="@color/colorPrimary"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -14,4 +14,10 @@
         <item name="windowNoTitle">true</item>
     </style>
 
+    <style name="sendMessageEditTextTheme">
+        <item name="android:textColorHighlight">@color/md_teal_100</item>
+        <item name="colorControlActivated">@color/colorPrimary</item>
+        <item name="colorControlHighlight">@color/colorPrimary</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Fixes issue #227: Cursor not visible in sendMessageLayout

Changes: Cursor Color and Highlight color was changed for EditText in order to make it visible. 

Screenshots for the change: 

![screenshot_20161017-183243](https://cloud.githubusercontent.com/assets/16309034/19438658/a665cdde-9498-11e6-999e-591c78f97742.png)


