### PR TITLE
Fix crash if throwable message is null

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
@@ -619,7 +619,11 @@ public class MainActivity extends AppCompatActivity {
 
                             @Override
                             public void onFailure(Call<SusiResponse> call, Throwable t) {
-                                Log.d(TAG, t.getLocalizedMessage());
+                                if (t.getLocalizedMessage() != null) {
+                                    Log.d(TAG, t.getLocalizedMessage());
+                                } else {
+                                    Log.d(TAG, "An error occurred", t);
+                                }
                                 recyclerAdapter.hideDots();
 
                                 if (!isNetworkConnected()) {


### PR DESCRIPTION
Possibly related to issue #289 

Changes: 
 - The app crashes if t.getLocalizedMessage() returns null. Hence, add a null check.

Screenshots for the change: 
NA