### PR TITLE
Fixes #220 Added crop box 16:9 in chat wallpaper

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
@@ -405,8 +405,8 @@ public class MainActivity extends AppCompatActivity {
         Intent cropIntent = new Intent("com.android.camera.action.CROP");
         cropIntent.setDataAndType(picUri, "image/*");
         cropIntent.putExtra("crop", "true");
-        cropIntent.putExtra("aspectX", 1);
-        cropIntent.putExtra("aspectY", 1);
+        cropIntent.putExtra("aspectX", 9);
+        cropIntent.putExtra("aspectY", 14);
         cropIntent.putExtra("outputX", 256);
         cropIntent.putExtra("outputY", 256);
         cropIntent.putExtra("return-data", true);


### PR DESCRIPTION
Fixes issue 220. 

Changes: before chat background crop box is squre. now crop box is rectangular.

Screenshots for the change: 
![screenshot_2016-10-25-18-27-03](https://cloud.githubusercontent.com/assets/15066782/19686928/0f5781fe-9ae1-11e6-8484-18790fddeab3.png)

