### PR TITLE
Fixes #348 Data loss on orientation

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/activities/LoginActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/LoginActivity.java
@@ -33,12 +33,18 @@ public class LoginActivity extends AppCompatActivity {
     TextInputLayout password;
     @BindView(R.id.log_in)
     Button logIn;
+
     
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_login);
         ButterKnife.bind(this);
+        if (savedInstanceState != null) {
+            email.getEditText().setText(savedInstanceState.getCharSequenceArray("savedStates")[0].toString());
+            password.getEditText().setText(savedInstanceState.getCharSequenceArray("savedStates")[1].toString());
+
+        }
     }
     
     @OnClick(R.id.sign_up)
@@ -116,6 +122,14 @@ public class LoginActivity extends AppCompatActivity {
                 pbutton.setTextColor(Color.BLUE);
             }
 
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        CharSequence values[] = {email.getEditText().getText().toString(), password.getEditText().getText().toString() };
+        outState.putCharSequenceArray("savedStates", values);
+
     }
+}
 
 

--- a/app/src/main/java/org/fossasia/susi/ai/activities/SignUpActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/SignUpActivity.java
@@ -39,6 +39,12 @@ public class SignUpActivity extends AppCompatActivity {
         setContentView(R.layout.activity_sign_up);
         ButterKnife.bind(this);
 
+        if(savedInstanceState!=null){
+            email.getEditText().setText(savedInstanceState.getCharSequenceArray("savedStates")[0].toString());
+            password.getEditText().setText(savedInstanceState.getCharSequenceArray("savedStates")[1].toString());
+            confirmPassword.getEditText().setText(savedInstanceState.getCharSequenceArray("savedStates")[2].toString());
+        }
+
         setupPasswordWatcher();
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
@@ -123,5 +129,10 @@ public class SignUpActivity extends AppCompatActivity {
         });
     }
 
-
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+        CharSequence values[] = {email.getEditText().getText().toString(), password.getEditText().getText().toString(), confirmPassword.getEditText().getText().toString() };
+        outState.putCharSequenceArray("savedStates", values);
+    }
 }


### PR DESCRIPTION
Fixes issue #348 

Changes: Saved the states before the orientation for both Login and Signup forms and updated the UI thereafter. Used savedInstanceState method.
 
Screenshots for the change: 
![device-2016-11-15-043512](https://cloud.githubusercontent.com/assets/16765805/20286553/3b9469fa-aaed-11e6-8d73-23faa5107638.png)
![device-2016-11-15-043601](https://cloud.githubusercontent.com/assets/16765805/20286554/3be847c8-aaed-11e6-91d2-99d1eebc99be.png)
![device-2016-11-15-043634](https://cloud.githubusercontent.com/assets/16765805/20286552/3b676c48-aaed-11e6-8f6a-cca2e78467f6.png)
![device-2016-11-15-043653](https://cloud.githubusercontent.com/assets/16765805/20286555/3bf6b024-aaed-11e6-9456-add59a92f9c5.png)

