### PR TITLE
Added support to use standard android Text to Speech

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
@@ -400,7 +400,8 @@ public class MainActivity extends AppCompatActivity {
                     @Override
                     public void onInit(int status) {
                         if (status != TextToSpeech.ERROR) {
-                            textToSpeech.setLanguage(Locale.UK);
+                            Locale locale = textToSpeech.getLanguage();
+                            textToSpeech.setLanguage(locale);
                             String spokenReply = reply;
                             if(isMap) {
                                 spokenReply = reply.substring(0, reply.indexOf("http"));

--- a/app/src/main/java/org/fossasia/susi/ai/activities/SettingsActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/SettingsActivity.java
@@ -1,8 +1,10 @@
 package org.fossasia.susi.ai.activities;
 
+import android.content.ComponentName;
 import android.content.Intent;
 import android.os.Bundle;
 import android.support.v7.app.AppCompatActivity;
+import android.support.v7.preference.Preference;
 import android.support.v7.preference.PreferenceFragmentCompat;
 
 import org.fossasia.susi.ai.R;
@@ -18,10 +20,23 @@ public class SettingsActivity extends AppCompatActivity {
     }
 
     public static class ChatSettingsFragment extends PreferenceFragmentCompat {
+        private Preference textToSpeech;
 
         @Override
         public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
             addPreferencesFromResource(R.xml.pref_settings);
+
+            textToSpeech = (Preference) getPreferenceManager().findPreference("Lang_Select");
+            textToSpeech.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+
+                @Override
+                public boolean onPreferenceClick(Preference preference) {
+                    Intent intent = new Intent();
+                    intent.setComponent( new ComponentName("com.android.settings","com.android.settings.Settings$TextToSpeechSettingsActivity" ));
+                    startActivity(intent);
+                    return true;
+                }
+            });
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,4 +73,6 @@
     <string name="message_search">Conducting a Search.....Launching Browser.</string>
     <string name="settings_mic">Mic Settings</string>
     <string name="settings_speech">Speech Settings</string>
+    <string name="Language">Language</string>
+    <string name="action_select_language">Select a Language</string>
 </resources>

--- a/app/src/main/res/xml/pref_settings.xml
+++ b/app/src/main/res/xml/pref_settings.xml
@@ -43,4 +43,11 @@
         android:summaryOff="@string/settings_enterPreference_summaryOff"
         android:summaryOn="@string/settings_enterPreference_summaryOn"
         android:title="@string/settings_speechAlways_label" />
+
+    <PreferenceScreen
+        android:title="@string/Language"
+        android:key="Lang_Select"
+        android:summary="@string/action_select_language">
+    </PreferenceScreen>
+
 </PreferenceScreen>


### PR DESCRIPTION
Fixes issue #350 . App not using standard voice and language of phone for text to speech.

Changes: Added support to use standard TTS voice with addition of Language preference inside of settings which on being clicked redirects to android TTS settings.

Screenshots for the change:  
![susi_settings](https://cloud.githubusercontent.com/assets/20367966/20476160/7e816a08-aff5-11e6-9b4b-e6706c5b3d10.jpg)


