### PR TITLE
Fixes #401: Implemented double back press to exit

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
@@ -96,6 +96,8 @@ public class MainActivity extends AppCompatActivity {
     private final int REQ_CODE_SPEECH_INPUT = 100;
     private final int SELECT_PICTURE = 200;
     private final int CROP_PICTURE = 400;
+    private  boolean atHome = true;
+    private boolean backPressedOnce = false;
 
     @BindView(R.id.coordinator_layout)
     CoordinatorLayout coordinatorLayout;
@@ -875,7 +877,25 @@ public class MainActivity extends AppCompatActivity {
             offset = 1;
             return;
         }
-        super.onBackPressed();
+        if(atHome){
+            if(backPressedOnce){
+                finish();
+            }
+            backPressedOnce=true;
+            Toast.makeText(this, R.string.exit, Toast.LENGTH_SHORT).show();
+            new Handler().postDelayed(new Runnable()
+            {
+                @Override
+                public void run()
+                {
+                    backPressedOnce= false;
+                }
+            }, 2000);
+        }
+        else if(!atHome){
+            atHome = true;
+        }
+
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,7 +29,7 @@
     <string name="error_msg">Please use the forgot password option, if you do not remember your password</string>
     <string name="email_invalid_title">Incorrect Email</string>
     <string name="password_invalid_title">Invalid Password</string>
-
+    <string name="exit">Press again to exit</string>
     <string name="error_cancelling_signUp_process_text">Are you sure, You want to stop the sign up process? You will not be able to use the Susi app without an account.</string>
 
 


### PR DESCRIPTION
Fixes issue [#401](https://github.com/fossasia/susi_android/issues/401)

Changes: Implemented double back press to exit. Now whenever someone presses the back button, a Toast message will appear to press the button again to exit.

Screenshots for the change: 
![whatsapp image 2016-12-09 at 1 52 30 am](https://cloud.githubusercontent.com/assets/21558765/21026363/436bfecc-bdb2-11e6-83ce-4597237469b2.jpeg)


