### PR TITLE
Fixes #405: Implemented number of messages copied

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/adapters/recycleradapters/ChatFeedRecyclerAdapter.java
+++ b/app/src/main/java/org/fossasia/susi/ai/adapters/recycleradapters/ChatFeedRecyclerAdapter.java
@@ -21,12 +21,14 @@ import android.text.style.BackgroundColorSpan;
 import android.util.Log;
 import android.util.Patterns;
 import android.util.SparseBooleanArray;
+import android.view.Gravity;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
+import android.widget.Toast;
 
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
@@ -695,8 +697,16 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
 
                         setClipboard(copyText);
                     }
-
-                    Snackbar.make(recyclerView, "Copied to Clipboard!!", Snackbar.LENGTH_LONG).show();
+                    if (nSelected == 1){
+                        Toast toast = Toast.makeText(recyclerView.getContext() , R.string.message_copied , Toast.LENGTH_LONG);
+                        toast.setGravity(Gravity.CENTER, 0, 0);
+                        toast.show();
+                    }
+                    else {
+                        Toast toast = Toast.makeText(recyclerView.getContext(), nSelected + " " + "Messages copied" , Toast.LENGTH_LONG);
+                        toast.setGravity(Gravity.CENTER, 0, 0);
+                        toast.show();
+                    }
                     actionMode.finish();
                     return true;
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -30,6 +30,7 @@
     <string name="email_invalid_title">Incorrect Email</string>
     <string name="password_invalid_title">Invalid Password</string>
     <string name="exit">Press again to exit</string>
+    <string name="message_copied">Message copied</string>
     <string name="error_cancelling_signUp_process_text">Are you sure, You want to stop the sign up process? You will not be able to use the Susi app without an account.</string>
 
 


### PR DESCRIPTION
Fixes issue [#405](https://github.com/fossasia/susi_android/issues/405)

Changes: Implemented number of messages copied and displays with a toast message

Screenshots for the change: 

**When only one message is copied.**

![2](https://cloud.githubusercontent.com/assets/21558765/21049303/19eee3ec-be3a-11e6-8577-d6db9956a2d1.jpeg)

**When multiple messages is copied**

![1](https://cloud.githubusercontent.com/assets/21558765/21049322/35e67e16-be3a-11e6-904a-8b8a9aed9f39.jpeg)



