### PR TITLE
Fixes #211: Fixed link preview issue

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/adapters/recycleradapters/ChatFeedRecyclerAdapter.java
+++ b/app/src/main/java/org/fossasia/susi/ai/adapters/recycleradapters/ChatFeedRecyclerAdapter.java
@@ -426,11 +426,14 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
         LinkPreviewCallback linkPreviewCallback = new LinkPreviewCallback() {
             @Override
             public void onPre() {
-                linkPreviewViewHolder.previewImageView.setVisibility(View.GONE);
-                linkPreviewViewHolder.descriptionTextView.setVisibility(View.GONE);
-                linkPreviewViewHolder.titleTextView.setVisibility(View.GONE);
-                linkPreviewViewHolder.previewLayout.setVisibility(View.GONE);
+
+                linkPreviewViewHolder.previewImageView.setVisibility(View.VISIBLE);
+                linkPreviewViewHolder.descriptionTextView.setVisibility(View.VISIBLE);
+                linkPreviewViewHolder.titleTextView.setVisibility(View.VISIBLE);
+                linkPreviewViewHolder.previewLayout.setVisibility(View.VISIBLE);
+
             }
+
 
             @Override
             public void onPos(final SourceContent sourceContent, boolean b) {
@@ -465,6 +468,9 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
 
             }
         };
+
+
+
 
         if (highlightMessagePosition == position) {
             String text = linkPreviewViewHolder.text.getText().toString();


### PR DESCRIPTION
**Fixes issue [#211](https://github.com/fossasia/susi_android/issues/211)**

Changes: Now whenever someone scrolls up such that link is not visible and comes back the preview of the link remains as it was earlier.

**Demo Video for the change:** 

You can see the demo video [here](https://drive.google.com/file/d/0Bx-iZdT4RNS9RlpCMm03bmFvbVk/view?usp=sharing)









