### PR TITLE
Fixes #410: Implemented number of messages to be deleted

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/adapters/recycleradapters/ChatFeedRecyclerAdapter.java
+++ b/app/src/main/java/org/fossasia/susi/ai/adapters/recycleradapters/ChatFeedRecyclerAdapter.java
@@ -101,6 +101,7 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
     private ActionMode actionMode;
     private SparseBooleanArray selectedItems;
     private AppCompatActivity currActivity;
+    private Toast toast;
     // For typing dots from Susi
     private TypingDotsHolder dotsHolder;
     private ZeroHeightHolder nullHolder;
@@ -633,33 +634,65 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
             switch (item.getItemId()) {
                 case R.id.menu_item_delete:
                     AlertDialog.Builder d = new AlertDialog.Builder(context);
-                    d.setMessage("Are you sure ?").
-                            setCancelable(false).
-                            setPositiveButton("Delete", new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
 
-                                    for (int i = getSelectedItems().size() - 1; i >= 0; i--) {
-                                        deleteMessage(getSelectedItems().get(i));
+                    if (getSelectedItems().size() == 1){
+
+                        d.setMessage("Delete message?").
+                                setCancelable(false).
+                                setPositiveButton("Delete", new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialog, int which) {
+
+                                        for (int i = getSelectedItems().size() - 1; i >= 0; i--) {
+                                            deleteMessage(getSelectedItems().get(i));
+                                        }
+                                        toast = Toast.makeText(recyclerView.getContext() , R.string.message_deleted , Toast.LENGTH_LONG);
+                                        toast.setGravity(Gravity.CENTER, 0, 0);
+                                        toast.show();
+                                        actionMode.finish();
+
                                     }
-                                    if (getSelectedItems().size() == 1)
-                                        Snackbar.make(recyclerView, " Message Deleted !!", Snackbar.LENGTH_LONG).show();
-                                    else
-                                        Snackbar.make(recyclerView, getSelectedItems().size() + " Messages Deleted !!", Snackbar.LENGTH_LONG).show();
+                                })
 
-                                    actionMode.finish();
+                                .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialog, int which) {
+                                        dialog.cancel();
+                                    }
+                                });
 
-                                }
-                            }).
-                            setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
-                                @Override
-                                public void onClick(DialogInterface dialog, int which) {
-                                    dialog.cancel();
-                                }
-                            });
+                    }
+
+                    else {
+
+                        d.setMessage("Delete " + getSelectedItems().size() + " messages?").
+                                setCancelable(false).
+                                setPositiveButton("Delete", new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialog, int which) {
+
+                                        for (int i = getSelectedItems().size() - 1; i >= 0; i--) {
+                                            deleteMessage(getSelectedItems().get(i));
+                                        }
+                                        toast = Toast.makeText(recyclerView.getContext() ,getSelectedItems().size() + " Messages deleted", Toast.LENGTH_LONG);
+                                        toast.setGravity(Gravity.CENTER, 0, 0);
+                                        toast.show();
+                                        actionMode.finish();
+
+                                    }
+                                })
+
+                                .setNegativeButton("Cancel", new DialogInterface.OnClickListener() {
+                                    @Override
+                                    public void onClick(DialogInterface dialog, int which) {
+                                        dialog.cancel();
+                                    }
+                                });
+
+                    }
+
 
                     AlertDialog alert = d.create();
-                    alert.setTitle("Delete");
                     alert.show();
                     Button cancel = alert.getButton(DialogInterface.BUTTON_NEGATIVE);
                     cancel.setTextColor(Color.BLUE);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -31,6 +31,7 @@
     <string name="password_invalid_title">Invalid Password</string>
     <string name="exit">Press again to exit</string>
     <string name="message_copied">Message copied</string>
+    <string name="message_deleted">Message deleted</string>
     <string name="error_cancelling_signUp_process_text">Are you sure, You want to stop the sign up process? You will not be able to use the Susi app without an account.</string>
 
 


### PR DESCRIPTION
Fixes issue [#410](https://github.com/fossasia/susi_android/issues/410)

Changes: Now the delete dialog shows how much messages the user is deleting with a toast message of number of messages deleted.

Screenshots for the change: 

![delete1](https://cloud.githubusercontent.com/assets/21558765/21072581/8f7ef5c6-beed-11e6-988a-82e37ba385bb.jpeg)


![delete2](https://cloud.githubusercontent.com/assets/21558765/21072583/9b2ce608-beed-11e6-8807-87350789c7c0.jpeg)

