### PR TITLE
Multiple APKs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -21,6 +21,28 @@ android {
             minifyEnabled false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
+        debug{
+            minifyEnabled false
+        }
+    }
+
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'x86', 'armeabi-v7a', 'mips', 'arm64-v8a', 'x86_64'
+            universalApk false
+        }
+    }
+
+    project.ext.versionCodes = [ 'armeabi-v7a': 1, 'arm64-v8a': 2, 'mips': 3, 'x86': 4, 'x86_64': 5]
+
+    android.applicationVariants.all { variant ->
+        // assign different version code for each output
+        variant.outputs.each { output ->
+            output.versionCodeOverride =
+                    project.ext.versionCodes.get(output.getFilter(com.android.build.OutputFile.ABI), 0) * 1000000 + android.defaultConfig.versionCode
+        }
     }
 
     lintOptions {
@@ -43,6 +65,7 @@ dependencies {
     */
     compile 'com.jakewharton:butterknife:8.4.0'
     apt 'com.jakewharton:butterknife-compiler:8.4.0'
+
     //For Glide
     compile 'com.github.bumptech.glide:glide:3.7.0'
     compile "com.android.support:support-v4:$support_lib_version"

--- a/app/src/main/java/org/fossasia/susi/ai/activities/ChangePasswordActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/ChangePasswordActivity.java
@@ -124,13 +124,12 @@ public class ChangePasswordActivity extends AppCompatActivity {
                     Button logIn = alert.getButton(DialogInterface.BUTTON_POSITIVE);
                     logIn.setTextColor(getResources().getColor(R.color.md_blue_500));
 
-                }
-                else{
+                } else {
                     AlertDialog.Builder alertDialog = new AlertDialog.Builder(ChangePasswordActivity.this);
                     alertDialog.setCancelable(false);
                     alertDialog.setTitle(getString(R.string.error_invalid_token));
                     alertDialog.setMessage(getString(R.string.email_token_string_message));
-                    alertDialog.setPositiveButton("Retry",null);
+                    alertDialog.setPositiveButton("Retry", null);
                     AlertDialog alert = alertDialog.create();
                     alert.show();
                     Button retry = alert.getButton(DialogInterface.BUTTON_POSITIVE);

--- a/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
@@ -103,6 +103,7 @@ public class MainActivity extends AppCompatActivity {
     private final int REQ_CODE_SPEECH_INPUT = 100;
     private final int SELECT_PICTURE = 200;
     private final int CROP_PICTURE = 400;
+
     @BindView(R.id.coordinator_layout)
     CoordinatorLayout coordinatorLayout;
     @BindView(R.id.rv_chat_feed)
@@ -115,6 +116,7 @@ public class MainActivity extends AppCompatActivity {
     ImageButton btnSpeak;
     @BindView(R.id.date)
     TextView dates;
+
     private boolean atHome = true;
     private boolean backPressedOnce = false;
     private FloatingActionButton fab_scrollToEnd;

--- a/app/src/main/java/org/fossasia/susi/ai/helper/CredentialHelper.java
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/CredentialHelper.java
@@ -9,6 +9,7 @@ import org.fossasia.susi.ai.R;
 
 import java.util.regex.Pattern;
 
+
 /**
  * Created by saurabh on 11/10/16.
  */
@@ -61,4 +62,6 @@ public class CredentialHelper {
             return false;
         }
     }
+
+
 }

--- a/exec/apk-gen.sh
+++ b/exec/apk-gen.sh
@@ -6,8 +6,8 @@ git config --global user.email "harshithdwivedi@gmail.com"
 
 git clone --quiet --branch=apk https://the-dagger:$GITHUB_API_KEY@github.com/fossasia/susi_android apk > /dev/null
 ls
-cp -r ${HOME}/${CIRCLE_PROJECT_REPONAME}/app/build/outputs/apk/app-debug.apk apk/susi-debug.apk
-cp -r ${HOME}/${CIRCLE_PROJECT_REPONAME}/app/build/outputs/apk/app-release-unsigned.apk apk/susi-release.apk
+cp -r ${HOME}/${CIRCLE_PROJECT_REPONAME}/app/build/outputs/apk/app-x86-debug.apk apk/susi-debug.apk
+cp -r ${HOME}/${CIRCLE_PROJECT_REPONAME}/app/build/outputs/apk/app-x86-release-unsigned.apk apk/susi-release.apk
 cd apk
 git add .
 git commit -m "[Circle CI] Update Susi Apk"


### PR DESCRIPTION
Apk size reduced by 60 percent

Fixes issue #435 

Changes: build.gradle was configured to generate multiple APKs for 'x86', 'armeabi-v7a', 'mips', 'arm64-v8a' and 'x86_64' architecture. This finally reduced APK size from earlier 8.7 MB to 3.8 MB average.

![screenshot 46](https://cloud.githubusercontent.com/assets/11005121/21487764/d71f4f12-cbf8-11e6-97df-2c68c5c55a37.png)
Screenshots for the change: 
