### PR TITLE
Fixes #290: Proposed and implemented bug and crash logs using Fabric Crashlytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,27 @@ We have the following branches
  * **master**
    This contains shipped code. After significant features/bugfixes are accumulated on development, we make a version update, and make a release.
 
+
+##For Developers: Adding Fabric API KEY
+1. Go to AndroidFest.xml
+Replace the fabric_api_key with the Real Fabric API Key
+Add: <meta-data android:name="io.fabric.ApiKey" android:value="fabric_api_key" /> 
+
+2. Open the app/fabric.properties:
+Replace the fabric_api_key with your actual Fabric API Secret.
+
+3. Open MainApplication.java, 
+	a) After adding the API KEYS and API Secret
+	Uncomment the line: Fabric.with(this, new Crashlytics()) 
+
+	b) Add imports :
+		import com.crashlytics.android.Crashlytics;
+		import io.fabric.sdk.android.Fabric;
+
+4. Uncomment the line in the app/gradle
+	Line: apply plugin: 'io.fabric'
+    
+
 ## Code practices
 
 Please help us follow the best practice to make it easy for the reviewer as well as the contributor. We want to focus on the code quality more than on managing pull request ethics. 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,4 +1,19 @@
+buildscript {
+    repositories {
+        maven { url 'https://maven.fabric.io/public' }
+    }
+
+    dependencies {
+        classpath 'io.fabric.tools:gradle:1.+'
+    }
+}
 apply plugin: 'com.android.application'
+//apply plugin: 'io.fabric'
+
+repositories {
+    maven { url 'https://maven.fabric.io/public' }
+}
+
 apply plugin: 'android-apt'
 apply plugin: 'realm-android'
 
@@ -95,4 +110,7 @@ dependencies {
 
     //waiting dots
     compile 'com.github.tajchert:WaitingDots:0.3.2'
+    compile('com.crashlytics.sdk.android:crashlytics:2.6.5@aar') {
+        transitive = true;
+    }
 }

--- a/app/fabric.properties
+++ b/app/fabric.properties
@@ -1,0 +1,4 @@
+#Contains API Secret used to validate your application. Commit to internal source control; avoid making secret public.
+#Wed Dec 28 02:19:42 IST 2016
+#Replace the fabric_api_secret with your actual Fabric API Secret.
+apiSecret= fabric_api_secret

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -46,6 +46,15 @@
             android:name=".activities.ChangePasswordActivity"
             android:windowSoftInputMode="stateHidden|adjustResize"
             android:theme="@style/Theme.AppCompat.Light.DarkActionBar"/>
+        <!--
+        For Developers:
+        Replay the fabric_api_key to your actual API KEY
+        <meta-data
+            android:name="io.fabric.ApiKey"
+            android:value="fabric_api_key" />
+        -->
+
     </application>
 
 </manifest>
+

--- a/app/src/main/java/org/fossasia/susi/ai/MainApplication.java
+++ b/app/src/main/java/org/fossasia/susi/ai/MainApplication.java
@@ -23,6 +23,9 @@ public class MainApplication extends Application {
     @Override
     public void onCreate() {
         super.onCreate();
+//        For Developers: Uncomment the below line after adding the API KEYS
+//        for Instructions check the README.md
+//        Fabric.with(this, new Crashlytics());
         instance = this;
         // The Realm file will be located in Context.getFilesDir() with name "default.realm"
         Realm.init(this);


### PR DESCRIPTION
Fixes issue #290 

After a request by the developer, we can provide them the API Key until the final release of the product as sharing the API Key publicly is dangerous. Someone could this API key and  produce an app which could  destroys our analytics and can gain access user credentials.

![screenshot 30](https://cloud.githubusercontent.com/assets/6136117/21508558/f90c032c-cca7-11e6-86eb-039adf5b5613.png)
