### PR TITLE
Fixes #446 Now photos can be selected using Google photos

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission android:name="com.android.alarm.permission.SET_ALARM"/>
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
         android:name=".MainApplication"


### PR DESCRIPTION
Fixes issue #446 : Wallpaper can now be selected using Google photos

Changes: Previously, the wallpaper selection using Google photos gave an error message "Unable to load image". Now it can be selected using the Google photos app. What i have tried is writing to temp file and return temp image URI, if it has authority in content URI.

Screen shots for the change:  
![ezgif com-d1d4b3b856](https://cloud.githubusercontent.com/assets/20367966/22596265/d7d125c2-ea50-11e6-98b8-a4b4492bcc40.gif)



