### PR TITLE
Fixes issue #513 : Login bug fix

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/activities/LoginActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/LoginActivity.java
@@ -81,6 +81,7 @@ public class LoginActivity extends AppCompatActivity {
         logIn.setEnabled(false);
         final ProgressDialog progressDialog = new ProgressDialog(this);
         progressDialog.setMessage("Logging in...");
+        progressDialog.setCancelable(false);
         progressDialog.show();
         final Call<LoginResponse> authResponseCall = new ClientBuilder().getSusiApi()
                 .login(email.getEditText().getText().toString().trim().toLowerCase(),


### PR DESCRIPTION
Fixes issue #513 

Changes: The login process used to stop and a "internet connectivity problem" error used to be thrown if the user interacted with the screen while the login was in process. This issue has now been fixed and interacting with the screen now does not throw the error.

Screenshots for the change: 

Now;
![screenshot_20170213-233844](https://cloud.githubusercontent.com/assets/23133275/22896456/23b2294e-f246-11e6-9c36-00a231fca042.png)
