### PR TITLE
Fixes #527 : changes to the editText field of the Chat Activity

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -47,7 +47,7 @@
                 android:imeOptions="actionSend"
                 android:inputType="text"
                 android:theme="@style/sendMessageEditTextTheme"
-                android:layout_gravity="center_vertical"/>
+                android:layout_gravity="top|left"/>
 
 
             <android.support.design.widget.FloatingActionButton


### PR DESCRIPTION
initially the app having "enter send field in settings disabled" looked like this:

![16731186_10210485505328384_225370993_o](https://cloud.githubusercontent.com/assets/8268392/22941120/45108616-f30a-11e6-84ff-4bfcbc1feb9d.png)
 
And now like this:

![16776071_10210485451967050_925263669_o](https://cloud.githubusercontent.com/assets/8268392/22941141/532daa6c-f30a-11e6-858f-72a03690fcd6.png)

Changed the layout_gravity field and also increased the max lines it will show in the edit text field.