### PR TITLE
Fixes # 522 : mark messages as important

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -6,12 +6,12 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
-    <uses-permission android:name="com.android.alarm.permission.SET_ALARM"/>
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="com.android.alarm.permission.SET_ALARM" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:name=".MainApplication"
@@ -30,8 +30,8 @@
         <activity
             android:name=".activities.SignUpActivity"
             android:theme="@style/SignUp_Theme"
-            tools:replace = "android:theme"
-            android:windowSoftInputMode="stateHidden|adjustResize" />
+            android:windowSoftInputMode="stateHidden|adjustResize"
+            tools:replace="android:theme" />
         <activity
             android:name=".activities.LoginActivity"
             android:theme="@style/Login_Theme"
@@ -44,14 +44,15 @@
         </activity>
         <activity
             android:name=".activities.ForgotPasswordActivity"
-            android:windowSoftInputMode="stateHidden|adjustResize"
-            android:theme="@style/Theme.AppCompat.Light.DarkActionBar" />
+            android:theme="@style/Theme.AppCompat.Light.DarkActionBar"
+            android:windowSoftInputMode="stateHidden|adjustResize" />
         <activity
             android:name=".activities.ChangePasswordActivity"
-            android:windowSoftInputMode="stateHidden|adjustResize"
-            android:theme="@style/Theme.AppCompat.Light.DarkActionBar"/>
-        <activity android:name=".helper.GetVideos"
-            android:theme="@style/Theme.AppCompat.Dialog"/>
+            android:theme="@style/Theme.AppCompat.Light.DarkActionBar"
+            android:windowSoftInputMode="stateHidden|adjustResize" />
+        <activity
+            android:name=".helper.GetVideos"
+            android:theme="@style/Theme.AppCompat.Dialog" />
         <!--
         For Developers:
         Replay the fabric_api_key to your actual API KEY
@@ -60,7 +61,7 @@
             android:value="fabric_api_key" />
         -->
 
+        <activity android:name=".activities.ImportantMessages"></activity>
     </application>
 
 </manifest>
-

--- a/app/src/main/java/org/fossasia/susi/ai/activities/ImportantMessages.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/ImportantMessages.java
@@ -1,0 +1,95 @@
+package org.fossasia.susi.ai.activities;
+
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.support.v4.content.ContextCompat;
+import android.support.v7.app.AppCompatActivity;
+import android.os.Bundle;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.util.Base64;
+import android.view.View;
+import android.widget.TextView;
+
+import com.bumptech.glide.Glide;
+
+import org.fossasia.susi.ai.R;
+import org.fossasia.susi.ai.adapters.recycleradapters.ChatFeedRecyclerAdapter;
+import org.fossasia.susi.ai.helper.Constant;
+import org.fossasia.susi.ai.helper.PrefManager;
+import org.fossasia.susi.ai.model.ChatMessage;
+
+import io.realm.Realm;
+import io.realm.RealmResults;
+
+public class ImportantMessages extends AppCompatActivity {
+
+    private Realm realm;
+    private RecyclerView rvChatImportant;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_important_messages);
+
+        realm = Realm.getDefaultInstance();
+        rvChatImportant = (RecyclerView) findViewById(R.id.rv_chat_important);
+        setChatBackground();
+        getSupportActionBar().setDisplayShowHomeEnabled(true);
+        getSupportActionBar().setTitle("");
+        getSupportActionBar().setIcon(R.drawable.susi);
+        setupAdapter();
+
+    }
+    public void setChatBackground() {
+        String previouslyChatImage = PrefManager.getString(Constant.IMAGE_DATA, "");
+        Drawable bg;
+        if (previouslyChatImage.equalsIgnoreCase(getString(R.string.background_no_wall))) {
+            //set no wall
+            getWindow().getDecorView()
+                    .setBackgroundColor(ContextCompat.getColor(this, R.color.default_bg));
+        } else if (!previouslyChatImage.equalsIgnoreCase("")) {
+            byte[] b = Base64.decode(previouslyChatImage, Base64.DEFAULT);
+            Bitmap bitmap = BitmapFactory.decodeByteArray(b, 0, b.length);
+            bg = new BitmapDrawable(getResources(), bitmap);
+            //set Drawable bitmap which taking from gallery
+            getWindow().setBackgroundDrawable(bg);
+        } else {
+            //set default layout when app launch first time
+            getWindow().getDecorView()
+                    .setBackgroundColor(ContextCompat.getColor(this, R.color.default_bg));
+        }
+    }
+
+    private void setupAdapter() {
+        rvChatImportant = (RecyclerView) findViewById(R.id.rv_chat_important);
+        LinearLayoutManager linearLayoutManager = new LinearLayoutManager(this);
+        linearLayoutManager.setStackFromEnd(true);
+        rvChatImportant.setLayoutManager(linearLayoutManager);
+        rvChatImportant.setHasFixedSize(false);
+        RealmResults<ChatMessage> importantMessages = realm.where(ChatMessage.class).equalTo("isImportant",true).findAll().sort("id");
+        TextView tv_msg = (TextView) findViewById(R.id.tv_empty_list);
+        if(importantMessages.size()!=0)
+            tv_msg.setVisibility(View.INVISIBLE);
+        ChatFeedRecyclerAdapter recyclerAdapter = new ChatFeedRecyclerAdapter(Glide.with(this), this, importantMessages, true);
+        rvChatImportant.setAdapter(recyclerAdapter);
+        rvChatImportant.addOnLayoutChangeListener(new View.OnLayoutChangeListener() {
+            @Override
+            public void onLayoutChange(View view, int left, int top, int right, int bottom,
+                                       int oldLeft, int oldTop, int oldRight, int oldBottom) {
+                if (bottom < oldBottom) {
+                    rvChatImportant.postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            int scrollTo = rvChatImportant.getAdapter().getItemCount() - 1;
+                            scrollTo = scrollTo >= 0 ? scrollTo : 0;
+                            rvChatImportant.scrollToPosition(scrollTo);
+                        }
+                    }, 10);
+                }
+            }
+        });
+    }
+}

--- a/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
@@ -1492,6 +1492,10 @@ public class MainActivity extends AppCompatActivity {
                 Button pbutton = alert.getButton(DialogInterface.BUTTON_POSITIVE);
                 pbutton.setTextColor(Color.BLACK);
                 return true;
+            case R.id.action_important:
+                Intent intent = new Intent(MainActivity.this,ImportantMessages.class);
+                startActivity(intent);
+                return true;
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/org/fossasia/susi/ai/adapters/recycleradapters/ChatFeedRecyclerAdapter.java
+++ b/app/src/main/java/org/fossasia/susi/ai/adapters/recycleradapters/ChatFeedRecyclerAdapter.java
@@ -133,6 +133,7 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
     private String linkurl;
     private Bitmap bmp;
     private URL urlimage;
+    private RealmResults<ChatMessage> important;
 
     public ChatFeedRecyclerAdapter(RequestManager glide, @NonNull Context context, @Nullable OrderedRealmCollection<ChatMessage> data, boolean autoUpdate) {
         super(context, data, autoUpdate);
@@ -189,6 +190,7 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
         super.onAttachedToRecyclerView(recyclerView);
         this.recyclerView = recyclerView;
         realm = Realm.getDefaultInstance();
+
     }
 
     @Override
@@ -497,171 +499,171 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
 
 
 
-       if(model.getWebSearch()==null) {
+        if(model.getWebSearch()==null) {
 
 
-           websearchholder.descriptionTextView.setVisibility(View.GONE);
-           websearchholder.titleTextView.setVisibility(View.GONE);
-           websearchholder.previewImageView.setVisibility(View.GONE);
+            websearchholder.descriptionTextView.setVisibility(View.GONE);
+            websearchholder.titleTextView.setVisibility(View.GONE);
+            websearchholder.previewImageView.setVisibility(View.GONE);
 
-           final WebSearchClient apiService = WebSearchApi.getClient().create(WebSearchClient.class);
-
-
-           Call<WebSearch> call = apiService.getresult(web);
+            final WebSearchClient apiService = WebSearchApi.getClient().create(WebSearchClient.class);
 
 
-           call.enqueue(new Callback<WebSearch>() {
-               @Override
-               public void onResponse(Call<WebSearch> call, Response<WebSearch> response) {
-                   Log.e(TAG, response.toString());
+            Call<WebSearch> call = apiService.getresult(web);
 
 
-
-                   if (response.body() != null && response.body().getRelatedTopics().size() != 0) {
-
-                       Log.v(TAG , response.body().toString());
-
-                       des = response.body().getRelatedTopics().get(0).getText();
-                       title = response.body().getHeading();
-                       url = response.body().getRelatedTopics().get(0).getIcon().getUrl();
-                       linkurl = response.body().getRelatedTopics().get(0).getDes();
-
-
-                       websearchholder.descriptionTextView.setVisibility(View.VISIBLE);
-                       websearchholder.titleTextView.setVisibility(View.VISIBLE);
-
-                       websearchholder.descriptionTextView.setText(des);
-                       websearchholder.titleTextView.setText(title);
-
-                       realm.beginTransaction();
-                       Realm realm = Realm.getDefaultInstance();
-                       final WebSearchModel webSearch = realm.createObject(WebSearchModel.class);
-
-                       webSearch.setHeadline(title);
-                       webSearch.setBody(des);
-                       webSearch.setUrl(linkurl);
-
-                       if(url!=null)
-                       {
-                           Log.v(TAG , url);
-                           webSearch.setImageURL(url);
-                       }
-
-
-                       if (url != null) {
-
-                           websearchholder.previewImageView.setVisibility(View.VISIBLE);
-                           Log.v(TAG , url);
-
-                           glide.load(url)
-                                   .crossFade()
-                                   .into(websearchholder.previewImageView);
-
-                       }else {
-                           websearchholder.previewImageView.setVisibility(View.GONE);
-
-                       }
-
-
-                       websearchholder.previewLayout.setOnClickListener(new View.OnClickListener() {
-                           @Override
-                           public void onClick(View view) {
-
-                               if (linkurl != null) {
-                                   websearchholder.onClick(view);
-                                   Uri webpage = Uri.parse(linkurl);
-
-                                   Intent intent = new Intent(Intent.ACTION_VIEW, webpage);
-                                   if (intent.resolveActivity(currContext.getPackageManager()) != null) {
-                                       currContext.startActivity(intent);
-                                   }
-                               }
-                           }
-                       });
-
-                       model.setWebSearch(webSearch);
-                       realm.copyToRealmOrUpdate(model);
-                       realm.commitTransaction();
+            call.enqueue(new Callback<WebSearch>() {
+                @Override
+                public void onResponse(Call<WebSearch> call, Response<WebSearch> response) {
+                    Log.e(TAG, response.toString());
 
 
 
-                   } else {
+                    if (response.body() != null && response.body().getRelatedTopics().size() != 0) {
 
-                       websearchholder.previewImageView.setVisibility(View.GONE);
-                       websearchholder.descriptionTextView.setVisibility(View.VISIBLE);
-                       websearchholder.titleTextView.setVisibility(View.VISIBLE);
+                        Log.v(TAG , response.body().toString());
 
-                       websearchholder.descriptionTextView.setText(R.string.websearchnull);
-                       websearchholder.titleTextView.setText(R.string.websearchnull);
-
-                       realm.beginTransaction();
-                       Realm realm = Realm.getDefaultInstance();
-                       final WebSearchModel webSearchnull = realm.createObject(WebSearchModel.class);
+                        des = response.body().getRelatedTopics().get(0).getText();
+                        title = response.body().getHeading();
+                        url = response.body().getRelatedTopics().get(0).getIcon().getUrl();
+                        linkurl = response.body().getRelatedTopics().get(0).getDes();
 
 
-                       webSearchnull.setHeadline(context.getString(R.string.websearchnull));
-                       webSearchnull.setBody(context.getString(R.string.websearchnull));
-                       webSearchnull.setUrl(null);
+                        websearchholder.descriptionTextView.setVisibility(View.VISIBLE);
+                        websearchholder.titleTextView.setVisibility(View.VISIBLE);
 
-                       model.setWebSearch(webSearchnull);
-                       realm.copyToRealmOrUpdate(model);
-                       realm.commitTransaction();
+                        websearchholder.descriptionTextView.setText(des);
+                        websearchholder.titleTextView.setText(title);
 
+                        realm.beginTransaction();
+                        Realm realm = Realm.getDefaultInstance();
+                        final WebSearchModel webSearch = realm.createObject(WebSearchModel.class);
 
-                   }
+                        webSearch.setHeadline(title);
+                        webSearch.setBody(des);
+                        webSearch.setUrl(linkurl);
 
-
-               }
-
-               @Override
-               public void onFailure(Call<WebSearch> call, Throwable t) {
-                   Log.e(TAG, "error" + t.toString());
-               }
-
-           });
-
+                        if(url!=null)
+                        {
+                            Log.v(TAG , url);
+                            webSearch.setImageURL(url);
+                        }
 
 
+                        if (url != null) {
 
-       }else {
+                            websearchholder.previewImageView.setVisibility(View.VISIBLE);
+                            Log.v(TAG , url);
 
-           websearchholder.descriptionTextView.setText(model.getWebSearch().getBody());
-           websearchholder.titleTextView.setText(model.getWebSearch().getHeadline());
+                            glide.load(url)
+                                    .crossFade()
+                                    .into(websearchholder.previewImageView);
 
-           if (model.getWebSearch().getImageURL() != null) {
+                        }else {
+                            websearchholder.previewImageView.setVisibility(View.GONE);
 
-               websearchholder.previewImageView.setVisibility(View.VISIBLE);
-
-               Log.v(TAG , model.getWebSearch().getImageURL());
-
-               glide.load(model.getWebSearch().getImageURL())
-                       .crossFade()
-                       .into(websearchholder.previewImageView);
-
-           }else {
-
-               websearchholder.previewImageView.setVisibility(View.GONE);
-           }
+                        }
 
 
-           websearchholder.previewLayout.setOnClickListener(new View.OnClickListener() {
-               @Override
-               public void onClick(View view) {
+                        websearchholder.previewLayout.setOnClickListener(new View.OnClickListener() {
+                            @Override
+                            public void onClick(View view) {
 
-                   if (model.getWebSearch() != null && model.getWebSearch().getUrl() != null) {
-                       websearchholder.onClick(view);
-                       Uri webpage = Uri.parse(model.getWebSearch().getUrl());
+                                if (linkurl != null) {
+                                    websearchholder.onClick(view);
+                                    Uri webpage = Uri.parse(linkurl);
 
-                       Intent intent = new Intent(Intent.ACTION_VIEW, webpage);
-                       if (intent.resolveActivity(currContext.getPackageManager()) != null) {
-                           currContext.startActivity(intent);
-                       }
-                   }
-               }
-           });
+                                    Intent intent = new Intent(Intent.ACTION_VIEW, webpage);
+                                    if (intent.resolveActivity(currContext.getPackageManager()) != null) {
+                                        currContext.startActivity(intent);
+                                    }
+                                }
+                            }
+                        });
+
+                        model.setWebSearch(webSearch);
+                        realm.copyToRealmOrUpdate(model);
+                        realm.commitTransaction();
 
 
-       }
+
+                    } else {
+
+                        websearchholder.previewImageView.setVisibility(View.GONE);
+                        websearchholder.descriptionTextView.setVisibility(View.VISIBLE);
+                        websearchholder.titleTextView.setVisibility(View.VISIBLE);
+
+                        websearchholder.descriptionTextView.setText(R.string.websearchnull);
+                        websearchholder.titleTextView.setText(R.string.websearchnull);
+
+                        realm.beginTransaction();
+                        Realm realm = Realm.getDefaultInstance();
+                        final WebSearchModel webSearchnull = realm.createObject(WebSearchModel.class);
+
+
+                        webSearchnull.setHeadline(context.getString(R.string.websearchnull));
+                        webSearchnull.setBody(context.getString(R.string.websearchnull));
+                        webSearchnull.setUrl(null);
+
+                        model.setWebSearch(webSearchnull);
+                        realm.copyToRealmOrUpdate(model);
+                        realm.commitTransaction();
+
+
+                    }
+
+
+                }
+
+                @Override
+                public void onFailure(Call<WebSearch> call, Throwable t) {
+                    Log.e(TAG, "error" + t.toString());
+                }
+
+            });
+
+
+
+
+        }else {
+
+            websearchholder.descriptionTextView.setText(model.getWebSearch().getBody());
+            websearchholder.titleTextView.setText(model.getWebSearch().getHeadline());
+
+            if (model.getWebSearch().getImageURL() != null) {
+
+                websearchholder.previewImageView.setVisibility(View.VISIBLE);
+
+                Log.v(TAG , model.getWebSearch().getImageURL());
+
+                glide.load(model.getWebSearch().getImageURL())
+                        .crossFade()
+                        .into(websearchholder.previewImageView);
+
+            }else {
+
+                websearchholder.previewImageView.setVisibility(View.GONE);
+            }
+
+
+            websearchholder.previewLayout.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+
+                    if (model.getWebSearch() != null && model.getWebSearch().getUrl() != null) {
+                        websearchholder.onClick(view);
+                        Uri webpage = Uri.parse(model.getWebSearch().getUrl());
+
+                        Intent intent = new Intent(Intent.ACTION_VIEW, webpage);
+                        if (intent.resolveActivity(currContext.getPackageManager()) != null) {
+                            currContext.startActivity(intent);
+                        }
+                    }
+                }
+            });
+
+
+        }
 
 
 
@@ -689,12 +691,6 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
         final ChatMessage model = getData().get(position);
         linkPreviewViewHolder.text.setText(model.getContent());
         linkPreviewViewHolder.timestampTextView.setText(model.getTimeStamp());
-        if (getItemViewType(position) == USER_WITHLINK) {
-            if (model.getIsDelivered())
-                linkPreviewViewHolder.receivedTick.setImageResource(R.drawable.check);
-            else
-                linkPreviewViewHolder.receivedTick.setImageResource(R.drawable.clock);
-        }
         linkPreviewViewHolder.backgroundLayout.setBackgroundColor(ContextCompat.getColor(currContext, isSelected(position) ? R.color.translucent_blue : android.R.color.transparent));
 
         if (model.getWebLinkData() == null) {
@@ -793,6 +789,12 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
             }
             linkPreviewViewHolder.text.setText(modify);
         }
+        if (getItemViewType(position) == USER_WITHLINK) {
+            if (model.getIsDelivered())
+                linkPreviewViewHolder.receivedTick.setImageResource(R.drawable.check);
+            else
+                linkPreviewViewHolder.receivedTick.setImageResource(R.drawable.clock);
+        }
     }
 
     private void handleItemEvents(final PieChartViewHolder pieChartViewHolder, final int position) {
@@ -867,6 +869,17 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
         });
     }
 
+    public void markImportant(final int position) {
+        realm.executeTransaction(new Realm.Transaction() {
+            @Override
+            public void execute(Realm realm) {
+                ChatMessage chatMessage = getItem(position);
+                chatMessage.setIsImportant(true);
+                realm.copyToRealmOrUpdate(chatMessage);
+            }
+        });
+    }
+
     private void removeDates(){
         realm.executeTransaction(new Realm.Transaction() {
             @Override
@@ -900,7 +913,7 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
         }
     }
 
-    private void toggleSelectedItem(int position) {
+    private void  toggleSelectedItem(int position) {
 
         toggleSelection(position);
         int count = getSelectedItemCount();
@@ -1099,6 +1112,24 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
                     actionMode.finish();
                     return true;
 
+
+                case R.id.menu_item_important:
+                    nSelected = getSelectedItems().size();
+                    if (nSelected >0)
+                    {
+                        for (int i = nSelected - 1; i >= 0; i--) {
+                            markImportant(getSelectedItems().get(i));
+                        }
+                        Toast.makeText(context,nSelected+" messages marked important",Toast.LENGTH_SHORT).show();
+                        important = realm.where(ChatMessage.class).equalTo("isImportant", true).findAll().sort("id");
+                        for(int i=0;i<important.size();++i)
+                            Log.i("message ",""+important.get(i).getContent());
+                        Log.i("total ",""+important.size());
+                        actionMode.finish();
+                    }
+                    return true;
+
+
                 default:
                     return false;
             }
@@ -1120,5 +1151,6 @@ public class ChatFeedRecyclerAdapter extends SelectableAdapter implements Messag
             sendIntent.setType("text/plain");
             currContext.startActivity(sendIntent);
         }
+
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/model/ChatMessage.java
+++ b/app/src/main/java/org/fossasia/susi/ai/model/ChatMessage.java
@@ -18,7 +18,7 @@ public class ChatMessage extends RealmObject {
     private WebLink webLinkData;
     private WebSearchModel webSearch;
 
-    private boolean isImage, isMine, isMap, isPieChart , isWebSearch, isDelivered, isHavingLink, isSearchResult, isDate;
+    private boolean isImage, isMine, isMap, isPieChart , isWebSearch, isDelivered, isHavingLink, isSearchResult, isDate, isImportant;
 
     public ChatMessage() {
         datumRealmList = new RealmList<>();
@@ -163,5 +163,15 @@ public class ChatMessage extends RealmObject {
 
     public void setSearchResult(boolean searchResult) {
         isSearchResult = searchResult;
+    }
+
+    public void setIsImportant(boolean isImportant)
+    {
+        this.isImportant = isImportant;
+    }
+
+    public boolean isImportant()
+    {
+        return isImportant;
     }
 }

--- a/app/src/main/res/drawable/ic_grade_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_grade_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/app/src/main/res/drawable/ic_star_white_24dp.xml
+++ b/app/src/main/res/drawable/ic_star_white_24dp.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#ffffff"
+        android:pathData="M12,17.27L18.18,21l-1.64,-7.03L22,9.24l-7.19,-0.61L12,2 9.19,8.63 2,9.24l5.46,4.73L5.82,21z"/>
+</vector>

--- a/app/src/main/res/layout/activity_important_messages.xml
+++ b/app/src/main/res/layout/activity_important_messages.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/activity_important_messages"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context="org.fossasia.susi.ai.activities.ImportantMessages">
+
+    <TextView
+        android:id="@+id/tv_empty_list"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="No messages have been marked important..."/>
+
+    <android.support.v7.widget.RecyclerView
+        android:id="@+id/rv_chat_important"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:layout_above="@+id/send_message_layout"
+        android:layout_alignParentTop="true"
+        android:layout_marginBottom="@dimen/margin_very_small"
+        android:layout_marginTop="@dimen/margin_very_small"
+        android:scrollbars="vertical"/>
+
+</RelativeLayout>
+

--- a/app/src/main/res/menu/menu_main.xml
+++ b/app/src/main/res/menu/menu_main.xml
@@ -23,6 +23,12 @@
         app:showAsAction="always"/>
 
     <item
+        android:id="@+id/action_important"
+        android:orderInCategory="99"
+        android:title="@string/action_important"
+        app:showAsAction="never"/>
+
+    <item
         android:id="@+id/action_settings"
         android:orderInCategory="100"
         android:title="@string/action_settings"

--- a/app/src/main/res/menu/menu_selection_mode.xml
+++ b/app/src/main/res/menu/menu_selection_mode.xml
@@ -17,5 +17,9 @@
         android:icon="@drawable/ic_share_white_24dp"
         android:title="@string/share_items" />
 
+    <item android:id="@+id/menu_item_important"
+        app:showAsAction="always"
+        android:icon="@drawable/ic_star_white_24dp"
+        android:title="@string/action_important" />
 
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
     <string name="promo_msg_template">Hey, try this up! - %s . You will love it!</string>
     <string name="error_msg_retry">Please Retry Again</string>
     <string name="app_share_url" translatable="false">https://play.google.com/store/apps/details?id=%s</string>
+    <string name="action_important">Important Messages</string>
 </resources>
 
 


### PR DESCRIPTION
Fixes # 522 : mark messages as important

added resources

updates!

adapter added but an unrecognized bug

finalized!

ready for pr

Fixes issue #522 

Changes: 

added a star button to mark message(s) important. provided a card in overflow menu to view important messages. on selecting important messages from the overflow menu, new activity opens up, giving out the messages marked as important. 

Screenshots for the change: 

![screenshot_20170302-081214](https://cloud.githubusercontent.com/assets/14837478/23490734/1fc1f742-ff20-11e6-992c-d9b0f1546f0a.png)
![screenshot_20170302-081217](https://cloud.githubusercontent.com/assets/14837478/23490735/1fcadc22-ff20-11e6-87bd-c868ad494e0c.png)
![screenshot_20170302-081222](https://cloud.githubusercontent.com/assets/14837478/23490736/1fd1f28c-ff20-11e6-9d42-5e5b4dcb9cbf.png)

@the-dagger @jig08 please review! :)