### PR TITLE
fixes #628, added auto complete suggestion for email address

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
     <uses-permission android:name="android.permission.READ_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_CALENDAR" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.GET_ACCOUNTS" />
 
     <application
         android:name=".MainApplication"

--- a/app/src/main/java/org/fossasia/susi/ai/activities/ForgotPasswordActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/ForgotPasswordActivity.java
@@ -10,6 +10,7 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.AutoCompleteTextView;
 import android.widget.Button;
 import android.widget.RadioButton;
 
@@ -32,6 +33,8 @@ public class ForgotPasswordActivity extends AppCompatActivity {
 
     @BindView(R.id.forgot_email)
     protected TextInputLayout email;
+    @BindView(R.id.autoemail)
+    protected AutoCompleteTextView autoemail;
     @BindView(R.id.reset_button)
     protected Button resetButton;
     @BindView(R.id.susi_default)
@@ -60,6 +63,7 @@ public class ForgotPasswordActivity extends AppCompatActivity {
         if (getSupportActionBar() != null) {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
+        CredentialHelper.addAdapterToViews(autoemail, this);
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/susi/ai/activities/LoginActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/LoginActivity.java
@@ -10,6 +10,7 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
+import android.widget.AutoCompleteTextView;
 import android.widget.Button;
 import android.widget.RadioButton;
 import android.widget.Toast;
@@ -35,6 +36,8 @@ public class LoginActivity extends AppCompatActivity {
 
     @BindView(R.id.email)
     TextInputLayout email;
+    @BindView(R.id.autoemail)
+    AutoCompleteTextView autoemail;
     @BindView(R.id.password)
     TextInputLayout password;
     @BindView(R.id.log_in)
@@ -67,6 +70,7 @@ public class LoginActivity extends AppCompatActivity {
                 url.setVisibility(View.GONE);
             }
         }
+        CredentialHelper.addAdapterToViews(autoemail, this);
     }
 
     @OnClick(R.id.personal_server)

--- a/app/src/main/java/org/fossasia/susi/ai/activities/SignUpActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/SignUpActivity.java
@@ -10,6 +10,7 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.AutoCompleteTextView;
 import android.widget.Button;
 import android.widget.RadioButton;
 import android.widget.Toast;
@@ -33,6 +34,8 @@ public class SignUpActivity extends AppCompatActivity {
 
     @BindView(R.id.email)
     TextInputLayout email;
+    @BindView(R.id.autoemail)
+    AutoCompleteTextView autoemail;
     @BindView(R.id.password)
     TextInputLayout password;
     @BindView(R.id.confirm_password)
@@ -73,6 +76,7 @@ public class SignUpActivity extends AppCompatActivity {
         } else {
             url.setVisibility(View.GONE);
         }
+        CredentialHelper.addAdapterToViews(autoemail, this);
     }
 
     @Override

--- a/app/src/main/java/org/fossasia/susi/ai/helper/CredentialHelper.java
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/CredentialHelper.java
@@ -1,13 +1,20 @@
 package org.fossasia.susi.ai.helper;
 
+import android.accounts.Account;
+import android.accounts.AccountManager;
 import android.content.Context;
 import android.support.design.widget.TextInputLayout;
 import android.text.TextUtils;
 import android.util.Patterns;
+import android.widget.ArrayAdapter;
+import android.widget.AutoCompleteTextView;
 
 import org.fossasia.susi.ai.R;
 
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.regex.Pattern;
 
 
@@ -88,5 +95,17 @@ public class CredentialHelper {
             inputLayout.setError(null);
             return false;
         }
+    }
+    public static void addAdapterToViews(AutoCompleteTextView autoemail,Context context) {
+
+        Account[] accounts = AccountManager.get(context).getAccounts();
+        Set<String> emailSet = new HashSet<String>();
+        for (Account account : accounts) {
+            if (Patterns.EMAIL_ADDRESS.matcher(account.name).matches()) {
+                emailSet.add(account.name);
+            }
+        }
+        autoemail.setAdapter(new ArrayAdapter<String>(context, android.R.layout.simple_dropdown_item_1line, new ArrayList<String>(emailSet)));
+
     }
 }

--- a/app/src/main/res/layout-land/activity_forgot_password.xml
+++ b/app/src/main/res/layout-land/activity_forgot_password.xml
@@ -27,11 +27,12 @@
             android:textColorHint="@color/md_white_1000"
             app:errorEnabled="true">
 
-            <android.support.design.widget.TextInputEditText
+            <AutoCompleteTextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/email_id_input"
                 android:inputType="textEmailAddress"
+                android:id="@+id/autoemail"
                 android:maxLines="1"
                 android:textAlignment="center"
                 android:textColor="@color/md_white_1000"

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -38,9 +38,10 @@
                 android:layout_marginTop="8dp"
                 app:errorEnabled="true">
 
-                <android.support.design.widget.TextInputEditText
+                <AutoCompleteTextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:id="@+id/autoemail"
                     android:hint="@string/email"
                     android:inputType="textEmailAddress"
                     android:textColor="@color/edit_text_login_screen"

--- a/app/src/main/res/layout-land/activity_sign_up.xml
+++ b/app/src/main/res/layout-land/activity_sign_up.xml
@@ -26,11 +26,12 @@
             android:textColorHint="@color/md_white_1000"
             app:errorEnabled="true">
 
-            <android.support.design.widget.TextInputEditText
+            <AutoCompleteTextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/email"
                 android:inputType="textEmailAddress"
+                android:id="@+id/autoemail"
                 app:theme="@style/Login_Theme"
                 android:textColorHighlight="@color/md_white_1000"
                 android:textColorHint="@color/md_white_1000"

--- a/app/src/main/res/layout/activity_forgot_password.xml
+++ b/app/src/main/res/layout/activity_forgot_password.xml
@@ -22,11 +22,12 @@
         android:textColorHint="@color/md_white_1000"
         app:errorEnabled="true">
 
-        <android.support.design.widget.TextInputEditText
+        <AutoCompleteTextView
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:hint="@string/email_id_input"
             android:inputType="textEmailAddress"
+            android:id="@+id/autoemail"
             app:theme="@style/Login_Theme"
             android:textColorHighlight="@color/md_white_1000"
             android:textColorHint="@color/md_white_1000"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -31,9 +31,10 @@
             android:layout_height="wrap_content"
             app:errorEnabled="true">
 
-            <android.support.design.widget.TextInputEditText
+            <AutoCompleteTextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:id="@+id/autoemail"
                 android:hint="@string/email"
                 android:textColor="@color/edit_text_login_screen"
                 android:inputType="textEmailAddress"

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -26,9 +26,10 @@
             android:textColorHint="@color/edit_text_login_screen"
             app:errorEnabled="true">
 
-            <android.support.design.widget.TextInputEditText
+            <AutoCompleteTextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
+                android:id="@+id/autoemail"
                 android:hint="@string/email"
                 android:inputType="textEmailAddress"
                 android:textColor="@color/edit_text_login_screen"


### PR DESCRIPTION
Fixes issue #628

Changes: 

- Added autocompleteTextview for email address in `LoginActivity`, `SignupActivity`, `ForgotPasswordActivity`.

- Added get accounts permission in `manifest.xml`

Screenshots for the change: 
![email_autocomplete](https://cloud.githubusercontent.com/assets/9781788/26272214/c5b66b80-3d30-11e7-9cb3-5f4c27a79b63.jpeg)

