### PR TITLE
fixes #496, added autoCompleteTextview in email for easy signup

### DIFF
--- a/app/src/androidTest/java/org/fossasia/susi/ai/TestLoginActivity.java
+++ b/app/src/androidTest/java/org/fossasia/susi/ai/TestLoginActivity.java
@@ -7,6 +7,7 @@ import android.support.test.rule.ActivityTestRule;
 import android.support.test.runner.AndroidJUnit4;
 import android.util.Log;
 import android.view.WindowManager;
+import android.widget.AutoCompleteTextView;
 import android.widget.RadioButton;
 
 import org.fossasia.susi.ai.activities.LoginActivity;
@@ -79,7 +80,7 @@ public class TestLoginActivity {
     @Test
     public void testSignIn() throws InterruptedException {
         Log.d(TAG, "running Sign in test");
-        final TextInputEditText emailInput = (TextInputEditText) ((TextInputLayout) mActivityRule.getActivity().findViewById(R.id.email)).getEditText();
+        final AutoCompleteTextView emailInput = (AutoCompleteTextView) ((TextInputLayout) mActivityRule.getActivity().findViewById(R.id.email)).getEditText();
         getInstrumentation().runOnMainSync(new Runnable() {
             public void run() {
                 emailInput.setText("singhalsaurabh95@gmail.com");

--- a/app/src/main/java/org/fossasia/susi/ai/activities/LoginActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/LoginActivity.java
@@ -10,6 +10,8 @@ import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.inputmethod.EditorInfo;
+import android.widget.ArrayAdapter;
+import android.widget.AutoCompleteTextView;
 import android.widget.Button;
 import android.widget.RadioButton;
 import android.widget.Toast;
@@ -22,6 +24,9 @@ import org.fossasia.susi.ai.rest.ClientBuilder;
 import org.fossasia.susi.ai.rest.model.LoginResponse;
 
 import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Set;
 
 import butterknife.BindView;
 import butterknife.ButterKnife;
@@ -35,6 +40,8 @@ public class LoginActivity extends AppCompatActivity {
 
     @BindView(R.id.email)
     TextInputLayout email;
+    @BindView(R.id.email_input)
+    AutoCompleteTextView autoCompleteEmail;
     @BindView(R.id.password)
     TextInputLayout password;
     @BindView(R.id.log_in)
@@ -45,6 +52,8 @@ public class LoginActivity extends AppCompatActivity {
     protected RadioButton personalServer;
     @BindView(R.id.input_url)
     protected TextInputLayout url;
+
+    private Set<String> savedEmails;
 
 
     @Override
@@ -66,6 +75,11 @@ public class LoginActivity extends AppCompatActivity {
             } else {
                 url.setVisibility(View.GONE);
             }
+        }
+        savedEmails = new HashSet<>();
+        if (PrefManager.getStringSet(Constant.SAVED_EMAIL) != null) {
+            savedEmails.addAll(PrefManager.getStringSet(Constant.SAVED_EMAIL));
+            autoCompleteEmail.setAdapter(new ArrayAdapter<>(this, android.R.layout.simple_list_item_1, new ArrayList<>(savedEmails)));
         }
     }
 
@@ -139,6 +153,9 @@ public class LoginActivity extends AppCompatActivity {
             public void onResponse(Call<LoginResponse> call, Response<LoginResponse> response) {
                 if (response.isSuccessful() && response.body() != null) {
                     Toast.makeText(LoginActivity.this, response.body().getMessage(), Toast.LENGTH_SHORT).show();
+                    // Save email for autocompletion
+                    savedEmails.add(email.getEditText().getText().toString());
+                    PrefManager.putStringSet(Constant.SAVED_EMAIL,savedEmails);
                     //Save token and expiry date.
                     PrefManager.putString(Constant.ACCESS_TOKEN, response.body().getAccessToken());
                     long validity = System.currentTimeMillis() + response.body().getValidSeconds() * 1000;

--- a/app/src/main/java/org/fossasia/susi/ai/activities/LoginActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/LoginActivity.java
@@ -41,7 +41,7 @@ public class LoginActivity extends AppCompatActivity {
     @BindView(R.id.email)
     TextInputLayout email;
     @BindView(R.id.email_input)
-    AutoCompleteTextView autoCompleteEmail;
+    protected AutoCompleteTextView autoCompleteEmail;
     @BindView(R.id.password)
     TextInputLayout password;
     @BindView(R.id.log_in)

--- a/app/src/main/java/org/fossasia/susi/ai/helper/Constant.java
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/Constant.java
@@ -21,4 +21,6 @@ public class Constant {
     public static final String LATITUDE = "latitude";
     public static final String LONGITUDE = "longitude";
     public static final String GEO_SOURCE = "geo_source";
+
+    public static final String SAVED_EMAIL="saved_email";
 }

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -38,10 +38,11 @@
                 android:layout_marginTop="8dp"
                 app:errorEnabled="true">
 
-                <android.support.design.widget.TextInputEditText
+                <AutoCompleteTextView
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:hint="@string/email"
+                    android:id="@+id/email_input"
                     android:inputType="textEmailAddress"
                     android:textColor="@color/edit_text_login_screen"
                     android:textColorHint="@color/edit_text_login_screen" />

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -31,10 +31,11 @@
             android:layout_height="wrap_content"
             app:errorEnabled="true">
 
-            <android.support.design.widget.TextInputEditText
+            <AutoCompleteTextView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/email"
+                android:id="@+id/email_input"
                 android:textColor="@color/edit_text_login_screen"
                 android:inputType="textEmailAddress"
                 android:textColorHint="@color/edit_text_login_screen" />


### PR DESCRIPTION
Fixes issue #496 

Changes:

- Added autoCompleteTextview in email for `LoginActivity`.
- Changed `TextInputEditText` to `AutoCompleteTextView` in `TestLoginActivity`.

Screenshots for the change: 
![email_autocomplete](https://cloud.githubusercontent.com/assets/9781788/26279792/5f605210-3dda-11e7-92b1-feb0f9d408c6.jpeg)