### PR TITLE
docs: Changed commit guidelines and screenshot structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,16 +28,17 @@ A native Android app.
 
 ## Screenshots
 
-  <table>
-    <tr>
-     <td><img src="docs/images/login.png"></td>
-     <td><img src="docs/images/signup.png"></td>
-     <td><img src="docs/images/main.png"></td>
-     <td><img src="docs/images/search.png"></td>
-     <td><img src="docs/images/voice_input.png"></td>
-     <td><img src="docs/images/settings.png"></td>
-    </tr>
-  </table>
+  <p align="center">
+    <img src="docs/images/login.png" height = "480" width="270"> 
+    <img src="docs/images/signup.png" height = "480" width="270"> 
+    <img src="docs/images/main.png" height = "480" width="270">
+  </p>
+
+  <p align="center">
+    <img src="docs/images/search.png" height = "480" width="270"> 
+    <img src="docs/images/voice_input.png" height = "480" width="270"> 
+    <img src="docs/images/settings.png" height = "480" width="270">
+  </p>
   
 ### Libraries used and their documentation
 
@@ -85,7 +86,7 @@ Replace the fabric_api_key with your actual Fabric API Secret.
 Please help us follow the best practice to make it easy for the reviewer as well as the contributor. We want to focus on the code quality more than on managing pull request ethics. 
 
  * Single commit per pull request
- * Reference the issue numbers in the commit message. Follow the pattern ``` Fixes #<issue number> <commit message>```
+ * For writing commit messages please read the [COMMITSTYLE](docs/commitStyle.md) carefully. Kindly adhere to the guidelines.
  * Follow uniform design practices. The design language must be consistent throughout the app.
  * The pull request will not get merged until and unless the commits are squashed. In case there are multiple commits on the PR, the commit author needs to squash them and not the maintainers cherrypicking and merging squashes.
  * If the PR is related to any front end change, please attach relevant screenshots in the pull request description.

--- a/docs/commitStyle.md
+++ b/docs/commitStyle.md
@@ -1,0 +1,55 @@
+## Commit Style Guidelines for Susi Android
+
+### Message Structure
+Commit messages consist of three distinct parts, separated by a blank line: the title, an optional body/content, and an optional footer/metadata. The layout looks like this:
+
+type: subject
+
+body
+
+footer
+
+***
+
+### Title
+The title consists of the subject and type of the commit message. 
+
+### Type
+The type is contained within the title and can be one of the following types:
+
+* **feat:** a new feature
+* **fix:** a bug fix
+* **docs:** changes to documentation
+* **style:** formatting, missing semi-colons, etc; no code change
+* **refactor:** refactoring production code
+* **test:** adding tests, refactoring test; no production code change
+* **chore:** updating build tasks, package manager configs, etc; no production code change
+
+### Subject
+The subject is a single short line summarising the change. It should be no greater than 50 characters, should begin with a capital letter and do not end with a period.
+
+Use an imperative tone to describe what a commit does, rather than what it did. For example, use fix; not fixed or fixes or fixing.
+
+For example: 
+- fix: Typo in Commit Style guidelines 
+- feat: Update UI of SessionDetailsActivity
+- fix: Remove deprecated methods
+- refactor: API endpoints and JSON assets
+instead of writing the following: 
+- Fixed bug with Y
+- Changing behaviour of X
+
+### Body
+The body includes the kind of information commit message (if any) should contain. 
+
+Not every commit requires both a subject and a body. Sometimes a single line is fine, especially when the change is self-explanatory and no further context is necessary, therefore it is optional. The body is used to explain the what and why of a commit, not the how.
+
+When writing a body, the blank line between the title and the body is required and we should try to limit the length of each line to no more than 72 characters.
+
+### The Footer
+The footer is optional and is used to reference issue tracker IDs.
+
+For example:
+Fixes #1170
+
+***


### PR DESCRIPTION
Fixes issue #638 
Changes: 
* Added commit style guidelines.
* Screenshots were looking small, changed the structure.

