### PR TITLE
Fix: Continuous selected chat bubbles strips

### DIFF
--- a/app/src/main/res/layout/item_susi_link_preview.xml
+++ b/app/src/main/res/layout/item_susi_link_preview.xml
@@ -4,7 +4,8 @@
               xmlns:tools="http://schemas.android.com/tools"
               android:id="@+id/background_layout"
               android:layout_width="match_parent"
-              android:layout_height="wrap_content">
+              android:layout_height="wrap_content"
+              android:layout_marginTop="@dimen/margin_very_small">
 
     <android.support.v7.widget.CardView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_susi_map.xml
+++ b/app/src/main/res/layout/item_susi_map.xml
@@ -5,7 +5,8 @@
               xmlns:tools="http://schemas.android.com/tools"
               android:id="@+id/background_layout"
               android:layout_width="match_parent"
-              android:layout_height="wrap_content">
+              android:layout_height="wrap_content"
+              android:layout_marginTop="@dimen/margin_very_small">
 
     <android.support.v7.widget.CardView
         android:layout_width="@dimen/message_layout_max_width"

--- a/app/src/main/res/layout/item_susi_message.xml
+++ b/app/src/main/res/layout/item_susi_message.xml
@@ -3,7 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/background_layout"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/margin_very_small">
 
     <android.support.v7.widget.CardView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_susi_piechart.xml
+++ b/app/src/main/res/layout/item_susi_piechart.xml
@@ -3,7 +3,8 @@
               xmlns:app="http://schemas.android.com/apk/res-auto"
               android:id="@+id/background_layout"
               android:layout_width="match_parent"
-              android:layout_height="wrap_content">
+              android:layout_height="wrap_content"
+              android:layout_marginTop="@dimen/margin_very_small">
 
     <android.support.v7.widget.CardView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_user_link_preview.xml
+++ b/app/src/main/res/layout/item_user_link_preview.xml
@@ -5,7 +5,8 @@
     android:id="@+id/background_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="right">
+    android:gravity="right"
+    android:layout_marginTop="@dimen/margin_very_small">
 
     <android.support.v7.widget.CardView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_user_message.xml
+++ b/app/src/main/res/layout/item_user_message.xml
@@ -4,7 +4,8 @@
               android:id="@+id/background_layout"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
-              android:gravity="right">
+              android:gravity="right"
+              android:layout_marginTop="@dimen/margin_very_small">
 
     <android.support.v7.widget.CardView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_waiting_dots.xml
+++ b/app/src/main/res/layout/item_waiting_dots.xml
@@ -3,7 +3,8 @@
               xmlns:app="http://schemas.android.com/apk/res-auto"
               android:id="@+id/background_layout"
               android:layout_width="match_parent"
-              android:layout_height="wrap_content">
+              android:layout_height="wrap_content"
+              android:layout_marginTop="@dimen/margin_very_small">
 
     <android.support.v7.widget.CardView
         android:layout_width="wrap_content"

--- a/app/src/main/res/layout/search_item.xml
+++ b/app/src/main/res/layout/search_item.xml
@@ -3,7 +3,8 @@
               xmlns:app="http://schemas.android.com/apk/res-auto"
               android:layout_width="wrap_content"
               android:layout_height="wrap_content"
-              xmlns:tools="http://schemas.android.com/tools">
+              xmlns:tools="http://schemas.android.com/tools"
+              android:layout_marginTop="@dimen/margin_very_small">
 
     <android.support.v7.widget.CardView
         android:layout_width="@dimen/websearch_card_width"

--- a/app/src/main/res/layout/search_list.xml
+++ b/app/src/main/res/layout/search_list.xml
@@ -4,7 +4,8 @@ xmlns:app="http://schemas.android.com/apk/res-auto"
 android:id="@+id/background_layout"
 android:layout_width="match_parent"
 android:layout_height="wrap_content"
-android:orientation="vertical">
+android:orientation="vertical"
+android:layout_marginTop="@dimen/margin_very_small">
 
 <android.support.v7.widget.CardView
     android:layout_width="wrap_content"


### PR DESCRIPTION
Fixes issue #673 
Changes: Adds margin at top of the message view. Now selected messages will appear in strips.

Screenshots for the change: **(UPDATED)**
![screenshot_2017-06-07-12-55-34](https://user-images.githubusercontent.com/13533840/26866947-034de06e-4b81-11e7-8afb-b0d2dc2dd42b.png)


