### PR TITLE
Fix : search action  is not working properly

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
+++ b/app/src/main/java/org/fossasia/susi/ai/activities/MainActivity.java
@@ -276,6 +276,7 @@ public class MainActivity extends AppCompatActivity {
         mapData = null;
         webSearch = "";
         isHavingLink = false;
+        answer = null;
 
         switch(actionType) {
             case Constant.ANCHOR :


### PR DESCRIPTION
Fixes issue #743 

Changes: initially answer text (I found this,here is the websearch result etc) was added with websearch,rss, map action type also. So on searching text like 'here', 'this' etc. text found in websearch, rss,map etc but since text is not shown in textview so app not show highlighted text. I changed the code to add answer in anchor and action type only.

Screenshots for the change: 
