### PR TITLE
Fix : Made the button corners rounded and aligned radio Buttons

### DIFF
--- a/app/src/main/res/drawable/rounded_button.xml
+++ b/app/src/main/res/drawable/rounded_button.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/md_grey_300"/>
+    <corners android:radius="5dp"/>
+</shape>

--- a/app/src/main/res/layout-land/activity_forgot_password.xml
+++ b/app/src/main/res/layout-land/activity_forgot_password.xml
@@ -40,7 +40,7 @@
         </android.support.design.widget.TextInputLayout>
 
         <RadioGroup
-            android:layout_width="match_parent"
+            android:layout_width="@dimen/activity_landscape_width"
             android:layout_height="wrap_content">
 
             <RadioButton
@@ -62,7 +62,7 @@
 
         <android.support.design.widget.TextInputLayout
             android:id="@+id/input_url"
-            android:layout_width="match_parent"
+            android:layout_width="@dimen/activity_landscape_width"
             android:layout_height="wrap_content"
             android:visibility="gone"
             app:errorEnabled="true">
@@ -81,7 +81,7 @@
             android:layout_width="@dimen/button_width"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:background="@color/md_grey_300"
+            android:background="@drawable/rounded_button"
             android:text="@string/reset"
             android:textColor="@color/colorPrimary" />
 

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -113,17 +113,17 @@
 
             <android.support.v7.widget.AppCompatButton
                 android:id="@+id/log_in"
-                android:layout_width="@dimen/button_width"
-                android:layout_height="wrap_content"
+                android:layout_width="130dp"
+                android:layout_height="30dp"
                 android:layout_gravity="center"
-                android:padding="12dp"
+                android:background="@drawable/rounded_button"
                 android:text="@string/activity_login_log_in"
                 android:textColor="@color/colorPrimary" />
 
 
             <TextView
                 android:id="@+id/forgot_password"
-                android:layout_width="wrap_content"
+                android:layout_width="250dp"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"
                 android:layout_marginTop="10dp"
@@ -132,6 +132,7 @@
                 android:textColor="?android:attr/textColorPrimary"
                 android:textSize="16sp"
                 android:textStyle="bold"
+                android:paddingLeft="48dp"
                 android:typeface="monospace" />
 
             <TextView

--- a/app/src/main/res/layout-land/activity_sign_up.xml
+++ b/app/src/main/res/layout-land/activity_sign_up.xml
@@ -82,7 +82,7 @@
         </android.support.design.widget.TextInputLayout>
 
         <RadioGroup
-            android:layout_width="match_parent"
+            android:layout_width="@dimen/activity_landscape_width"
             android:layout_height="wrap_content">
             <RadioButton
                 android:text="Susi AI Standard Server"
@@ -103,7 +103,7 @@
 
         <android.support.design.widget.TextInputLayout
             android:id="@+id/input_url"
-            android:layout_width="match_parent"
+            android:layout_width="@dimen/activity_landscape_width"
             android:layout_height="wrap_content"
             android:visibility="gone"
             app:errorEnabled="true">
@@ -122,7 +122,7 @@
             android:layout_width="@dimen/button_width"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:background="@color/md_grey_300"
+            android:background="@drawable/rounded_button"
             android:text="@string/sign_up"
             android:textColorHighlight="@color/md_white_1000"
             android:textColorHint="@color/md_white_1000"

--- a/app/src/main/res/layout/activity_forgot_password.xml
+++ b/app/src/main/res/layout/activity_forgot_password.xml
@@ -74,7 +74,7 @@
         android:layout_width="250dp"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_medium"
-        android:background="@color/md_grey_300"
+        android:background="@drawable/rounded_button"
         android:text="@string/reset"
         android:textColor="@color/colorPrimary" />
 

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -113,7 +113,7 @@
             android:layout_marginTop="@dimen/margin_medium"
             android:padding="@dimen/cmv_padding"
             android:text="@string/activity_login_log_in"
-            android:background="@color/md_grey_300"
+            android:background="@drawable/rounded_button"
             android:textColor="@color/colorPrimary"/>
 
         <TextView

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -119,7 +119,7 @@
             android:layout_width="250dp"
             android:layout_height="wrap_content"
             android:layout_marginTop="16dp"
-            android:background="@color/md_grey_300"
+            android:background="@drawable/rounded_button"
             android:text="@string/sign_up"
             android:textColor="@color/colorPrimary" />
     </LinearLayout>


### PR DESCRIPTION
Fixes issue #784


Changes: Made the Button corners rounded in both Landscape and Portrait mode of Sign Up,Forgot Password, and Login Activity

Also Left aligned the radio buttons in forgot password and sign up Activity

Screenshots for the change: 

![1](https://user-images.githubusercontent.com/21264401/27830416-fb9ec770-60e3-11e7-8374-3d3d00927995.jpeg)

![2](https://user-images.githubusercontent.com/21264401/27830427-01c9bfba-60e4-11e7-908d-958f659f5cc8.jpeg)

![10](https://user-images.githubusercontent.com/21264401/27830506-53da652a-60e4-11e7-8eed-289240f036e6.jpeg)


![3](https://user-images.githubusercontent.com/21264401/27830431-05f6e144-60e4-11e7-8d39-9d3558cd025d.jpeg)


![4](https://user-images.githubusercontent.com/21264401/27830438-0adeefbc-60e4-11e7-93fd-81cfcf67f451.jpeg)

![5](https://user-images.githubusercontent.com/21264401/27830444-0e78e38a-60e4-11e7-8a28-f21aadb10d7b.jpeg)


