### PR TITLE
Espresso test for SignUp and ForgetPassword Activities

### DIFF
--- a/app/src/androidTest/java/org/fossasia/susi/ai/ForgetPassTest.kt
+++ b/app/src/androidTest/java/org/fossasia/susi/ai/ForgetPassTest.kt
@@ -1,0 +1,90 @@
+package org.fossasia.susi.ai
+
+import android.support.design.widget.TextInputEditText
+import android.support.design.widget.TextInputLayout
+import android.support.test.InstrumentationRegistry
+import android.support.test.espresso.Espresso.*
+import android.support.test.espresso.action.ViewActions.*
+import android.support.test.espresso.assertion.ViewAssertions
+import android.support.test.espresso.matcher.ViewMatchers.*
+import android.support.test.filters.MediumTest
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import android.util.Log
+import android.view.WindowManager
+import org.fossasia.susi.ai.forgotPassword.ForgotPasswordActivity
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Created by mayanktripathi on 18/07/17.
+ */
+
+@RunWith(AndroidJUnit4::class)
+@MediumTest
+class ForgetPassTest {
+
+
+    @Rule @JvmField
+    val mActivityRule = ActivityTestRule(ForgotPasswordActivity::class.java)
+
+    @Before
+    fun unlockScreen() {
+        val activity = mActivityRule.activity
+        val wakeUpDevice = Runnable {
+            activity.window.addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON or
+                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+        activity.runOnUiThread(wakeUpDevice)
+    }
+
+    @Test
+    fun testUIViewsPresenceOnLoad() {
+        Log.d(ForgetPassTest.TAG, "running testUIViewsPresenceOnLoad..")
+
+        // checks if email input field is present
+        onView(withId(R.id.forgot_email)).check(ViewAssertions.matches(isDisplayed()))
+
+        // checks if reset button is present
+        onView(withId(R.id.reset_button)).check(ViewAssertions.matches(isDisplayed()))
+
+        // checks if radio buttons are present
+        onView(withId(R.id.susi_default)).check(ViewAssertions.matches(isDisplayed()))
+        onView(withId(R.id.personal_server)).check(ViewAssertions.matches(isDisplayed()))
+
+    }
+
+    @Test
+    fun testReset() {
+        Log.d(ForgetPassTest.TAG, "running resetPassword test..")
+
+        val emailInput = (mActivityRule.activity.findViewById(R.id.forgot_email) as TextInputLayout).editText as TextInputEditText?
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { emailInput!!.setText("mayank.trp@gmail.com") }
+
+        onView(withId(R.id.reset_button)).perform(click())
+
+    }
+
+    @Test
+    fun testPersonalServer() {
+        Log.d(ForgetPassTest.TAG, "running resetPassword test on personal server..")
+
+        val emailInput = (mActivityRule.activity.findViewById(R.id.forgot_email) as TextInputLayout).editText as TextInputEditText?
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { emailInput!!.setText("mayank.trp@gmail.com") }
+
+        onView(withId(R.id.personal_server)).perform(click())
+
+        val serverInput = (mActivityRule.activity.findViewById(R.id.input_url) as TextInputLayout).editText as TextInputEditText?
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { serverInput!!.setText("http://104.198.32.176/") }
+
+        onView(withId(R.id.reset_button)).perform(click())
+
+    }
+
+    companion object {
+        private val TAG = "ForgetPassTest"
+    }
+}

--- a/app/src/androidTest/java/org/fossasia/susi/ai/ForgetPassTest.kt
+++ b/app/src/androidTest/java/org/fossasia/susi/ai/ForgetPassTest.kt
@@ -21,6 +21,7 @@ import org.junit.runner.RunWith
 /**
  * Created by mayanktripathi on 18/07/17.
  */
+
 @RunWith(AndroidJUnit4::class)
 @MediumTest
 class ForgetPassTest {

--- a/app/src/androidTest/java/org/fossasia/susi/ai/ForgetPassTest.kt
+++ b/app/src/androidTest/java/org/fossasia/susi/ai/ForgetPassTest.kt
@@ -21,7 +21,6 @@ import org.junit.runner.RunWith
 /**
  * Created by mayanktripathi on 18/07/17.
  */
-
 @RunWith(AndroidJUnit4::class)
 @MediumTest
 class ForgetPassTest {

--- a/app/src/androidTest/java/org/fossasia/susi/ai/SignUpTest.kt
+++ b/app/src/androidTest/java/org/fossasia/susi/ai/SignUpTest.kt
@@ -1,0 +1,108 @@
+package org.fossasia.susi.ai
+
+import android.support.design.widget.TextInputEditText
+import android.support.design.widget.TextInputLayout
+import android.support.test.InstrumentationRegistry
+import android.support.test.espresso.Espresso.*
+import android.support.test.espresso.action.ViewActions
+import android.support.test.espresso.assertion.ViewAssertions.*
+import android.support.test.espresso.matcher.ViewMatchers.*
+import android.support.test.filters.MediumTest
+import android.support.test.rule.ActivityTestRule
+import android.support.test.runner.AndroidJUnit4
+import android.util.Log
+import android.view.WindowManager
+import org.fossasia.susi.ai.signup.SignUpActivity
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+/**
+ * Created by mayanktripathi on 18/07/17.
+ */
+
+@RunWith(AndroidJUnit4::class)
+@MediumTest
+class SignUpTest {
+
+
+    @Rule @JvmField
+    val mActivityRule = ActivityTestRule(SignUpActivity::class.java)
+
+    @Before
+    fun unlockScreen() {
+        val activity = mActivityRule.activity
+        val wakeUpDevice = Runnable {
+            activity.window.addFlags(WindowManager.LayoutParams.FLAG_TURN_SCREEN_ON or
+                    WindowManager.LayoutParams.FLAG_SHOW_WHEN_LOCKED or
+                    WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
+        }
+        activity.runOnUiThread(wakeUpDevice)
+    }
+
+    @Test
+    fun testUIViewsPresenceOnLoad() {
+        Log.d(SignUpTest.TAG, "running testUIViewsPresenceOnLoad..")
+
+        // checks if email input field is present
+        onView(withId(R.id.email)).check(matches(isDisplayed()))
+
+        // checks if password input field is present
+        onView(withId(R.id.password)).check(matches(isDisplayed()))
+
+        // checks if confirm password button is present
+        onView(withId(R.id.confirm_password)).check(matches(isDisplayed()))
+
+        // checks if radio buttons are present
+        onView(withId(R.id.susi_default)).check(matches(isDisplayed()))
+        onView(withId(R.id.personal_server)).check(matches(isDisplayed()))
+
+        // checks if sign up button is present
+        onView(withId(R.id.sign_up)).perform(ViewActions.scrollTo())
+        onView(withId(R.id.sign_up)).check(matches(isDisplayed()))
+
+    }
+
+    @Test
+    fun testSignUp() {
+        Log.d(SignUpTest.TAG, "running SignUp test..")
+
+        val emailInput = (mActivityRule.activity.findViewById(R.id.email) as TextInputLayout).editText as TextInputEditText?
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { emailInput!!.setText("mayank.trp@gmail.com") }
+
+        val passInput = (mActivityRule.activity.findViewById(R.id.password) as TextInputLayout).editText as TextInputEditText?
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { passInput!!.setText("abcdef") }
+
+        val conpassInput = (mActivityRule.activity.findViewById(R.id.confirm_password) as TextInputLayout).editText as TextInputEditText?
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { conpassInput!!.setText("abcdef") }
+
+        onView(withId(R.id.sign_up)).perform(ViewActions.click())
+    }
+
+    @Test
+    fun testPersonalServer() {
+        Log.d(SignUpTest.TAG, "running Personal Server test..")
+
+        val emailInput = (mActivityRule.activity.findViewById(R.id.email) as TextInputLayout).editText as TextInputEditText?
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { emailInput!!.setText("mayank.trp@gmail.com") }
+
+        val passInput = (mActivityRule.activity.findViewById(R.id.password) as TextInputLayout).editText as TextInputEditText?
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { passInput!!.setText("abcdef") }
+
+        val conpassInput = (mActivityRule.activity.findViewById(R.id.confirm_password) as TextInputLayout).editText as TextInputEditText?
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { conpassInput!!.setText("abcdef") }
+
+        onView(withId(R.id.personal_server)).perform(ViewActions.click())
+
+        val serverInput = (mActivityRule.activity.findViewById(R.id.input_url) as TextInputLayout).editText as TextInputEditText?
+        InstrumentationRegistry.getInstrumentation().runOnMainSync { serverInput!!.setText("http://104.198.32.176/") }
+
+        onView(withId(R.id.sign_up)).perform(ViewActions.click())
+    }
+
+    companion object {
+        private val TAG = "SignUpTest"
+    }
+
+}


### PR DESCRIPTION
Fixes issue #858

Have written unit test for SignUp/Forget Pass using Expresso testing framework.

Screenshots for the change: 
![screen shot 2017-07-18 at 2 51 06 pm](https://user-images.githubusercontent.com/22056321/28309957-92676eca-6bc8-11e7-8b54-ed1872e38f2c.png)
![screen shot 2017-07-18 at 2 50 33 pm](https://user-images.githubusercontent.com/22056321/28309959-92d35306-6bc8-11e7-85ed-959ffcd9b2d2.png)
