### PR TITLE
feat: Skill details fragment added

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
@@ -59,6 +59,7 @@ class ChatActivity: AppCompatActivity(), IChatView {
     var recordingThread: RecordingThread? = null
     lateinit var networkStateReceiver: BroadcastReceiver
     lateinit var progressDialog: ProgressDialog
+    var example: String = ""
 
     val afChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
         if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT || focusChange == AudioManager.AUDIOFOCUS_LOSS) {
@@ -74,15 +75,21 @@ class ChatActivity: AppCompatActivity(), IChatView {
 
         chatPresenter = ChatPresenter(this)
         chatPresenter.onAttach(this)
+
         setUpUI()
         initializationMethod(firstRun)
+
+        if(intent.getStringExtra("example") != null) {
+            example = intent.getStringExtra("example")
+        } else {
+            example = ""
+        }
 
         networkStateReceiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context, intent: Intent) {
                 chatPresenter.startComputingThread()
             }
         }
-        registerReceiver(networkStateReceiver, IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION))
     }
 
     // This method is used to set up the UI components
@@ -145,6 +152,7 @@ class ChatActivity: AppCompatActivity(), IChatView {
         et_message.setHorizontallyScrolling(false)
 
         et_message.addTextChangedListener(watch)
+
         et_message.setOnEditorActionListener({ _, actionId, _ ->
             var handled = false
             if (actionId == EditorInfo.IME_ACTION_SEND) {
@@ -405,6 +413,11 @@ class ChatActivity: AppCompatActivity(), IChatView {
     override fun onResume() {
         super.onResume()
         chatPresenter.getUndeliveredMessages()
+
+        if(!example.isEmpty()) {
+            chatPresenter.addToNonDeliveredList(example, example)
+            example = ""
+        }
 
         registerReceiver(networkStateReceiver, IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION))
 

--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatPresenter.kt
@@ -1,6 +1,7 @@
 package org.fossasia.susi.ai.chat
 
 import android.os.Handler
+import android.util.Log
 
 import org.fossasia.susi.ai.MainApplication
 import org.fossasia.susi.ai.R
@@ -260,6 +261,11 @@ class ChatPresenter(chatActivity: ChatActivity): IChatPresenter, IChatModel.OnRe
 
     //sends message to susi
     override fun sendMessage(query: String, actual: String) {
+        addToNonDeliveredList(query, actual)
+        computeThread().start()
+    }
+
+    override fun addToNonDeliveredList(query: String, actual: String) {
         val urlList = ParseSusiResponseHelper.extractUrls(query)
         val isHavingLink = !urlList.isEmpty()
 
@@ -279,7 +285,6 @@ class ChatPresenter(chatActivity: ChatActivity): IChatPresenter, IChatModel.OnRe
         databaseRepository.updateDatabase(newMessageIndex, actual, false, DateTimeHelper.date,
                 DateTimeHelper.currentTime, true, "", null, isHavingLink, null, "", "", this)
         getLocationFromLocationService()
-        computeThread().start()
     }
 
     override fun startComputingThread() {
@@ -293,7 +298,7 @@ class ChatPresenter(chatActivity: ChatActivity): IChatPresenter, IChatModel.OnRe
     }
 
     @Synchronized
-    fun computeOtherMessage() {
+    fun computeOtherMessage() { Log.v("chirag","chirag run")
         if (!nonDeliveredMessages.isEmpty()) {
             if (NetworkUtils.isNetworkConnected()) {
                 chatView?.showWaitingDots()

--- a/app/src/main/java/org/fossasia/susi/ai/chat/contract/IChatPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/contract/IChatPresenter.kt
@@ -25,6 +25,7 @@ interface IChatPresenter {
 
     //Interaction with susi
     fun sendMessage(query: String, actual: String)
+    fun addToNonDeliveredList(query:String, actual: String)
     fun startComputingThread()
 
     //Hotword Detection

--- a/app/src/main/java/org/fossasia/susi/ai/rest/responses/susi/SkillData.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/rest/responses/susi/SkillData.kt
@@ -2,12 +2,13 @@ package org.fossasia.susi.ai.rest.responses.susi
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import java.io.Serializable
 
 /**
  *
  * Created by chiragw15 on 16/8/17.
  */
-class SkillData {
+class SkillData: Serializable {
 
     @SerializedName("image")
     @Expose
@@ -23,7 +24,7 @@ class SkillData {
 
     @SerializedName("developer_privacy_policy")
     @Expose
-    var developerPrivacyPolicy: String ?= null
+    var developerPrivacyPolicy: String = ""
 
     @SerializedName("author")
     @Expose
@@ -35,11 +36,11 @@ class SkillData {
 
     @SerializedName("dynamic_content")
     @Expose
-    var dynamicContent: Boolean = false
+    var dynamicContent: Boolean ?= null
 
     @SerializedName("terms_of_use")
     @Expose
-    var termsOfUse: String ?= null
+    var termsOfUse: String = ""
 
     @SerializedName("descriptions")
     @Expose

--- a/app/src/main/java/org/fossasia/susi/ai/rest/responses/susi/SkillRating.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/rest/responses/susi/SkillRating.kt
@@ -2,12 +2,13 @@ package org.fossasia.susi.ai.rest.responses.susi
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import java.io.Serializable
 
 /**
  *
  * Created by chiragw15 on 18/8/17.
  */
-class SkillRating {
+class SkillRating: Serializable {
     @SerializedName("positive")
     @Expose
     var positive: Int = 0

--- a/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
@@ -48,6 +48,7 @@ class SkillsActivity : AppCompatActivity() {
 
     override fun onBackPressed() {
         super.onBackPressed()
+        overridePendingTransition(R.anim.trans_right_in, R.anim.trans_right_out)
         val fragment = fragmentManager.findFragmentByTag(TAG_SKILLS_FRAGMENT)
 
         if (fragment != null && fragment.isVisible) {
@@ -56,7 +57,7 @@ class SkillsActivity : AppCompatActivity() {
         } else {
             val skillFragment = SkillListingFragment()
             fragmentManager.beginTransaction()
-                    .replace(R.id.fragment_container, skillFragment, TAG_SKILLS_FRAGMENT)
+                    .add(R.id.fragment_container, skillFragment, TAG_SKILLS_FRAGMENT)
                     .commit()
         }
     }
@@ -71,7 +72,7 @@ class SkillsActivity : AppCompatActivity() {
                 } else {
                     val skillFragment = SkillListingFragment()
                     fragmentManager.beginTransaction()
-                            .replace(R.id.fragment_container, skillFragment, TAG_SKILLS_FRAGMENT)
+                            .add(R.id.fragment_container, skillFragment, TAG_SKILLS_FRAGMENT)
                             .commit()
                 }
             }
@@ -79,13 +80,13 @@ class SkillsActivity : AppCompatActivity() {
             R.id.menu_settings -> {
                 val settingsFragment = ChatSettingsFragment()
                 supportFragmentManager.beginTransaction()
-                        .replace(R.id.fragment_container, settingsFragment, TAG_SETTINGS_FRAGMENT)
+                        .add(R.id.fragment_container, settingsFragment, TAG_SETTINGS_FRAGMENT)
                         .commit()
             }
 
-            R.id.menu_about -> {
+            //R.id.menu_about -> {
                 //TODO : Add code for about section
-            }
+            //}
         }
         return super.onOptionsItemSelected(item);
     }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -1,0 +1,193 @@
+package org.fossasia.susi.ai.skills.skilldetails
+
+import android.app.Fragment
+import android.content.Intent
+import android.os.Build
+import android.os.Bundle
+import android.support.v7.widget.LinearLayoutManager
+import android.text.Html
+import android.text.method.LinkMovementMethod
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.squareup.picasso.Picasso
+import kotlinx.android.synthetic.main.fragment_skill_details.*
+import org.fossasia.susi.ai.R
+import org.fossasia.susi.ai.chat.ChatActivity
+import org.fossasia.susi.ai.rest.responses.susi.SkillData
+import org.fossasia.susi.ai.skills.SkillsActivity
+import org.fossasia.susi.ai.skills.skilldetails.adapters.recycleradapters.SkillExamplesAdapter
+import java.io.Serializable
+
+/**
+ *
+ * Created by chiragw15 on 24/8/17.
+ */
+class SkillDetailsFragment: Fragment() {
+
+    lateinit var skillData: SkillData
+    lateinit var skillGroup: String
+    val imageLink = "https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/general/"
+
+    companion object {
+        val SKILL_KEY = "skill_key"
+        val SKILL_GROUP = "skill_group"
+        fun newInstance(skillData: SkillData, skillGroup: String): SkillDetailsFragment {
+            val fragment = SkillDetailsFragment()
+            val bundle = Bundle()
+            bundle.putSerializable(SKILL_KEY, skillData as Serializable)
+            bundle.putString(SKILL_GROUP, skillGroup)
+            fragment.arguments = bundle
+
+            return fragment
+        }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        skillData = arguments.getSerializable(
+                SKILL_KEY) as SkillData
+        skillGroup = arguments.getString(SKILL_GROUP)
+        return inflater.inflate(R.layout.fragment_skill_details, container, false)
+    }
+
+    override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
+        if(skillData.skillName != null && !skillData.skillName.isEmpty())
+            (activity as SkillsActivity).title = skillData.skillName
+        setupUI()
+        super.onViewCreated(view, savedInstanceState)
+    }
+
+    fun setupUI() {
+        setImage()
+        setName()
+        setAuthor()
+        setTryButton()
+        setDescription()
+        setExamples()
+        setRating()
+        setDynamicContent()
+        setPolicy()
+        setTerms()
+    }
+
+    fun setImage() {
+        skill_detail_image.setImageResource(R.drawable.ic_susi)
+        if(skillData.image != null && !skillData.image.isEmpty()){
+            Picasso.with(activity.applicationContext).load(StringBuilder(imageLink)
+                    .append(skillGroup).append("/en/").append(skillData.image).toString())
+                    .fit().centerCrop()
+                    .into(skill_detail_image)
+        }
+    }
+
+    fun setName() {
+        skill_detail_title.text = activity.getString(R.string.no_skill_name)
+        if(skillData.skillName != null && !skillData.skillName.isEmpty()){
+            skill_detail_title.text = skillData.skillName
+        }
+    }
+
+    fun setAuthor() {
+        skill_detail_author.text = "Author : ${activity.getString(R.string.no_skill_author)}"
+        if(skillData.author != null && !skillData.author.isEmpty()){
+            if(skillData.authorUrl == null || skillData.authorUrl.isEmpty())
+                skill_detail_author.text = "Author : ${skillData.skillName}"
+            else {
+                skill_detail_author.linksClickable = true
+                skill_detail_author.movementMethod = LinkMovementMethod.getInstance()
+                if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    skill_detail_author.text = Html.fromHtml("Author : <a href=\"${skillData.authorUrl}\">${skillData.author}</a>", Html.FROM_HTML_MODE_COMPACT)
+                } else {
+                    skill_detail_author.text = Html.fromHtml("Author : <a href=\"${skillData.authorUrl}\">${skillData.author}</a>")
+                }
+            }
+        }
+    }
+
+    fun setTryButton() {
+        if(skillData.examples == null || skillData.examples.isEmpty())
+            skill_detail_try_button.visibility = View.GONE
+
+        skill_detail_try_button.setOnClickListener {
+            activity.overridePendingTransition(R.anim.trans_right_in, R.anim.trans_right_out)
+            val intent = Intent(activity, ChatActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+            if(skillData.examples != null && skillData.examples.isNotEmpty())
+                intent.putExtra("example",skillData.examples[0])
+            else
+                intent.putExtra("example","")
+            startActivity(intent)
+            activity.finish()
+        }
+    }
+
+    fun setDescription() {
+        skill_detail_description.text = activity.getString(R.string.no_skill_description)
+        if( skillData.descriptions != null && !skillData.descriptions.isEmpty()){
+            skill_detail_description.text = skillData.descriptions
+        }
+    }
+
+    fun setExamples() {
+        if(skillData.examples != null) {
+            skill_detail_examples.setHasFixedSize(true)
+            val mLayoutManager = LinearLayoutManager(activity, LinearLayoutManager.HORIZONTAL, false)
+            skill_detail_examples.layoutManager = mLayoutManager
+            skill_detail_examples.adapter = SkillExamplesAdapter(activity, skillData.examples)
+        }
+    }
+
+    fun setRating() {
+        if(skillData.skillRating == null) {
+            skill_detail_rating_positive.text = "Skill not rated yet"
+            skill_detail_rating_negative.visibility = View.GONE
+        } else {
+            skill_detail_rating_positive.text = "Positive: " + skillData.skillRating?.positive
+            skill_detail_rating_negative.text = "Negative: " + skillData.skillRating?.negative
+        }
+    }
+
+    fun setDynamicContent() {
+        if(skillData.dynamicContent == null) {
+            skill_detail_content.visibility = View.GONE
+        } else {
+            if(skillData.dynamicContent!!) {
+                skill_detail_content.text = "Content type: Dynamic"
+            } else {
+                skill_detail_content.text = "Content type: Static"
+            }
+        }
+    }
+
+    fun setPolicy() {
+        if(skillData.developerPrivacyPolicy == null || skillData.developerPrivacyPolicy.isEmpty()) {
+            skill_detail_policy.visibility = View.GONE
+        } else {
+            skill_detail_policy.linksClickable = true
+            skill_detail_policy.movementMethod = LinkMovementMethod.getInstance()
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                skill_detail_policy.text = Html.fromHtml("<a href=\"${skillData.developerPrivacyPolicy}\">Developer's Privacy Policy</a>", Html.FROM_HTML_MODE_COMPACT)
+            } else {
+                skill_detail_policy.text = Html.fromHtml("<a href=\"${skillData.developerPrivacyPolicy}\">Developer's Privacy Policy</a>")
+            }
+        }
+    }
+
+    fun setTerms() {
+        if(skillData.termsOfUse == null || skillData.termsOfUse.isEmpty()) {
+            skill_detail_terms.visibility = View.GONE
+        } else {
+            skill_detail_terms.linksClickable = true
+            skill_detail_terms.movementMethod = LinkMovementMethod.getInstance()
+            if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                skill_detail_terms.text = Html.fromHtml("<a href=\"${skillData.termsOfUse}\">Terms of use</a>", Html.FROM_HTML_MODE_COMPACT)
+            } else {
+                skill_detail_terms.text = Html.fromHtml("<a href=\"${skillData.termsOfUse}\">Terms of use</a>")
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+    }
+}

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/SkillExamplesAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/SkillExamplesAdapter.kt
@@ -1,0 +1,49 @@
+package org.fossasia.susi.ai.skills.skilldetails.adapters.recycleradapters
+
+import android.app.Activity
+import android.content.Context
+import android.content.Intent
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import org.fossasia.susi.ai.R
+import org.fossasia.susi.ai.chat.ChatActivity
+import org.fossasia.susi.ai.skills.skilldetails.adapters.viewholders.SkillExampleViewHolder
+
+/**
+ *
+ * Created by chiragw15 on 27/8/17.
+ */
+class SkillExamplesAdapter(val context: Context, val examples: List<String>): RecyclerView.Adapter<SkillExampleViewHolder>(),
+        SkillExampleViewHolder.ClickListener{
+
+    val clickListener: SkillExampleViewHolder.ClickListener = this
+
+    override fun onCreateViewHolder(parent: ViewGroup?, viewType: Int): SkillExampleViewHolder {
+        val itemView = LayoutInflater.from(parent?.context)
+                .inflate(R.layout.item_example_skill, parent, false)
+        return SkillExampleViewHolder(itemView, clickListener)
+    }
+
+    override fun getItemCount(): Int {
+        return examples.size
+    }
+
+    override fun onBindViewHolder(holder: SkillExampleViewHolder?, position: Int) {
+        if(examples[position] != null && !examples[position].isEmpty()) {
+            holder?.example?.text = examples[position]
+        }
+    }
+
+    override fun onItemClicked(position: Int) {
+        (context as Activity).overridePendingTransition(R.anim.trans_right_in, R.anim.trans_right_out)
+        val intent = Intent(context, ChatActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+        if(examples != null && examples.size !=0 && examples[position] != null)
+            intent.putExtra("example", examples[position])
+        else
+            intent.putExtra("example","")
+        context.startActivity(intent)
+        (context as Activity).finish()
+    }
+}

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/viewholders/SkillExampleViewHolder.java
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/viewholders/SkillExampleViewHolder.java
@@ -1,0 +1,41 @@
+package org.fossasia.susi.ai.skills.skilldetails.adapters.viewholders;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.TextView;
+
+import org.fossasia.susi.ai.R;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+/**
+ *
+ * Created by chiragw15 on 27/8/17.
+ */
+
+public class SkillExampleViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
+
+    @BindView(R.id.text)
+    public TextView example;
+
+    private SkillExampleViewHolder.ClickListener listener;
+
+    public SkillExampleViewHolder(View itemView, SkillExampleViewHolder.ClickListener clickListener) {
+        super(itemView);
+        ButterKnife.bind(this, itemView);
+        this.listener = clickListener;
+        itemView.setOnClickListener(this);
+    }
+
+    @Override
+    public void onClick(View view) {
+        if (listener != null) {
+            listener.onItemClicked(getAdapterPosition());
+        }
+    }
+
+    public interface ClickListener {
+        void onItemClicked(int position);
+    }
+}

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
@@ -2,7 +2,6 @@ package org.fossasia.susi.ai.skills.skilllisting
 
 import android.app.Fragment
 import android.os.Bundle
-import android.support.v7.app.AlertDialog
 import android.support.v7.widget.LinearLayoutManager
 import android.view.LayoutInflater
 import android.view.View
@@ -50,17 +49,9 @@ class SkillListingFragment: Fragment(), ISkillListingView {
         if(boolean) skillWait.visibility = View.VISIBLE else skillWait.visibility = View.GONE
     }
 
-    override fun displayErrorDialog() {
+    override fun displayError() {
         if(activity != null) {
-            val d = AlertDialog.Builder(activity)
-            d.setMessage(getString(R.string.error_skill_listing)).setCancelable(false).setPositiveButton("Okay") { dialog, _ ->
-                activity.onBackPressed()
-                dialog.cancel()
-            }
-
-            val alert = d.create()
-            alert.setTitle("Error")
-            alert.show()
+            error_skill_fetch.visibility = View.VISIBLE
         }
     }
 

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
@@ -40,34 +40,33 @@ class SkillListingPresenter: ISkillListingPresenter,
             skillListingModel.fetchSkills(groups[0], this)
         } else {
             skillListingView?.visibilityProgressBar(false)
-            skillListingView?.displayErrorDialog()
+            skillListingView?.displayError()
         }
     }
 
     override fun onGroupFetchFailure(t: Throwable) {
         skillListingView?.visibilityProgressBar(false)
-        skillListingView?.displayErrorDialog()
+        skillListingView?.displayError()
     }
 
     override fun onSkillFetchSuccess(response: Response<ListSkillsResponse>, group: String) {
+        skillListingView?.visibilityProgressBar(false)
         if (response.isSuccessful && response.body() != null) {
             skills.add(Pair(group, response.body().skillMap))
+            skillListingView?.updateAdapter(skills)
             count++
-            if(count == groupsCount) {
-                skillListingView?.visibilityProgressBar(false)
-                skillListingView?.updateAdapter(skills)
-            } else {
+            if(count != groupsCount) {
                 skillListingModel.fetchSkills(groups[count], this)
             }
         } else {
             skillListingView?.visibilityProgressBar(false)
-            skillListingView?.displayErrorDialog()
+            skillListingView?.displayError()
         }
     }
 
     override fun onSkillFetchFailure(t: Throwable) {
         skillListingView?.visibilityProgressBar(false)
-        skillListingView?.displayErrorDialog()
+        skillListingView?.displayError()
     }
 
     override fun onDetach() {

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
@@ -7,15 +7,19 @@ import android.view.ViewGroup
 import com.squareup.picasso.Picasso
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
+import org.fossasia.susi.ai.skills.SkillsActivity
+import org.fossasia.susi.ai.skills.skilldetails.SkillDetailsFragment
 import org.fossasia.susi.ai.skills.skilllisting.adapters.viewholders.SkillViewHolder
 
 /**
  *
  * Created by chiragw15 on 15/8/17.
  */
-class SkillListAdapter(val context: Context, val skillDetails:  Pair<String, Map<String, SkillData>>) : RecyclerView.Adapter<SkillViewHolder>() {
+class SkillListAdapter(val context: Context, val skillDetails:  Pair<String, Map<String, SkillData>>) : RecyclerView.Adapter<SkillViewHolder>(),
+        SkillViewHolder.ClickListener {
 
     val imageLink = "https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/general/"
+    val clickListener: SkillViewHolder.ClickListener = this
 
     override fun onBindViewHolder(holder: SkillViewHolder?, position: Int) {
         val skillData = skillDetails.second.values.toTypedArray()[position]
@@ -51,9 +55,22 @@ class SkillListAdapter(val context: Context, val skillDetails:  Pair<String, Map
         return skillDetails.second.size
     }
 
+    override fun onItemClicked(position: Int) {
+        val skillData = skillDetails.second.values.toTypedArray()[position]
+        val skillGroup = skillDetails.first.replace(" ","%20")
+        showSkillDetailFragment(skillData, skillGroup)
+    }
+
+    fun showSkillDetailFragment(skillData: SkillData, skillGroup: String) {
+        val skillDetailsFragment = SkillDetailsFragment.newInstance(skillData,skillGroup)
+        (context as SkillsActivity).fragmentManager.beginTransaction()
+                .add(R.id.fragment_container, skillDetailsFragment)
+                .commit()
+    }
+
     override fun onCreateViewHolder(parent: ViewGroup?, viewType: Int): SkillViewHolder {
         val itemView = LayoutInflater.from(parent?.context)
                 .inflate(R.layout.item_skill, parent, false)
-        return SkillViewHolder(itemView)
+        return SkillViewHolder(itemView, clickListener)
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/viewholders/SkillViewHolder.java
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/viewholders/SkillViewHolder.java
@@ -15,7 +15,7 @@ import butterknife.ButterKnife;
  * Created by chiragw15 on 18/8/17.
  */
 
-public class SkillViewHolder extends RecyclerView.ViewHolder {
+public class SkillViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
     @BindView(R.id.skill_preview_image)
     public ImageView previewImageView;
@@ -26,8 +26,23 @@ public class SkillViewHolder extends RecyclerView.ViewHolder {
     @BindView(R.id.skill_preview_example)
     public TextView skillPreviewExample;
 
-    public SkillViewHolder(View itemView) {
+    private ClickListener listener;
+
+    public SkillViewHolder(View itemView, ClickListener clickListener) {
         super(itemView);
         ButterKnife.bind(this, itemView);
+        this.listener = clickListener;
+        itemView.setOnClickListener(this);
+    }
+
+    @Override
+    public void onClick(View view) {
+        if (listener != null) {
+            listener.onItemClicked(getAdapterPosition());
+        }
+    }
+
+    public interface ClickListener {
+        void onItemClicked(int position);
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/contract/ISkillListingView.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/contract/ISkillListingView.kt
@@ -9,5 +9,5 @@ import org.fossasia.susi.ai.rest.responses.susi.SkillData
 interface ISkillListingView {
     fun visibilityProgressBar(boolean: Boolean)
     fun updateAdapter(skills: ArrayList<Pair<String, Map<String, SkillData>>>)
-    fun displayErrorDialog()
+    fun displayError()
 }

--- a/app/src/main/res/layout/fragment_skill_details.xml
+++ b/app/src/main/res/layout/fragment_skill_details.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+
+    <LinearLayout
+        android:orientation="vertical"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/md_white_1000"
+            android:padding="16dp">
+
+            <ImageView
+                android:id="@+id/skill_detail_image"
+                android:layout_width="80dp"
+                android:layout_height="80dp"
+                app:srcCompat="@drawable/ic_susi"
+                android:background="@color/md_white_1000"/>
+
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:layout_marginLeft="16dp"
+                android:background="@color/md_white_1000">
+
+                <TextView
+                    android:id="@+id/skill_detail_title"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Skill Name"
+                    android:textSize="24sp"
+                    android:layout_marginTop="8dp"
+                    android:textColor="@color/md_black_1000"
+                    android:background="@color/md_white_1000"/>
+
+                <TextView
+                    android:id="@+id/skill_detail_author"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="Author : Author name"
+                    android:layout_marginTop="8dp"
+                    android:background="@color/md_white_1000"/>
+            </LinearLayout>
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="right"
+            android:background="@color/md_white_1000">
+
+            <Button
+                android:id="@+id/skill_detail_try_button"
+                android:layout_width="100dp"
+                android:layout_height="40dp"
+                android:text="Try it"
+                android:layout_marginTop="8dp"
+                android:background="@color/colorPrimary"
+                android:textColor="@color/md_white_1000"
+                android:layout_marginRight="16dp"
+                android:layout_marginBottom="16dp"/>
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Description"
+                android:textSize="22dp"
+                android:layout_marginTop="8dp"
+                android:textColor="@color/md_black_1000" />
+
+            <TextView
+                android:id="@+id/skill_detail_description"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textSize="16sp"
+                android:layout_marginTop="8dp"
+                android:text="Description long"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Examples"
+                android:layout_marginTop="16dp"
+                android:textSize="22dp"
+                android:textColor="@color/md_black_1000"/>
+
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/skill_detail_examples"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"/>
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Rating"
+                android:textSize="22dp"
+                android:layout_marginTop="16dp"
+                android:textColor="@color/md_black_1000" />
+
+            <TextView
+                android:id="@+id/skill_detail_rating_positive"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Positive : 50"
+                android:layout_marginTop="8dp"/>
+
+            <TextView
+                android:id="@+id/skill_detail_rating_negative"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Negative : 50"
+                android:layout_marginTop="4dp"/>
+
+            <TextView
+                android:id="@+id/skill_detail_content"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Content Type : Dynamic"
+                android:layout_marginTop="16dp"
+                android:textSize="18dp"
+                android:textColor="@color/md_black_1000"/>
+
+            <TextView
+                android:id="@+id/skill_detail_policy"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Developers Privacy Policy"
+                android:layout_marginTop="16dp"/>
+
+            <TextView
+                android:id="@+id/skill_detail_terms"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Terms of use"/>
+
+        </LinearLayout>
+    </LinearLayout>
+</ScrollView>

--- a/app/src/main/res/layout/fragment_skill_listing.xml
+++ b/app/src/main/res/layout/fragment_skill_listing.xml
@@ -15,4 +15,15 @@ xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="@dimen/progress_bar_size"
         android:layout_height="@dimen/progress_bar_size"
         android:layout_gravity="center"/>
+
+    <TextView
+        android:id="@+id/error_skill_fetch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/error_skill_listing"
+        android:textSize="18sp"
+        android:padding="16dp"
+        android:textColor="@color/colorPrimary"
+        android:visibility="gone"/>
 </FrameLayout>

--- a/app/src/main/res/layout/item_example_skill.xml
+++ b/app/src/main/res/layout/item_example_skill.xml
@@ -1,0 +1,23 @@
+ <LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/background_layout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/message_card_margin_small"
+        android:layout_marginLeft="@dimen/message_card_margin_medium"
+        android:layout_marginTop="@dimen/message_card_margin_small"
+        android:padding="10dp"
+        android:background="@drawable/rounded_layout">
+
+    <TextView
+        android:id="@+id/text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:maxWidth="@dimen/message_layout_max_width"
+        android:paddingBottom="@dimen/message_textview_bottom_padding"
+        android:text="@string/hello_world"
+        android:background="@color/md_white_1000"
+        android:textColor="@color/message_text_color"
+        android:textSize="@dimen/message_text_size" />
+
+</LinearLayout>

--- a/app/src/main/res/menu/skills_activity_menu.xml
+++ b/app/src/main/res/menu/skills_activity_menu.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Add it when needed
     <item android:id="@+id/menu_about"
         android:icon="@drawable/ic_about"
         android:title="About" />
-
+    -->
     <item android:id="@+id/menu_settings"
         android:icon="@drawable/ic_settings_24dp"
         android:title="Settings" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -158,6 +158,7 @@
     <string name="skills">Skills</string>
     <string name="skill_title">Skill Title</string>
     <string name="skills_activity">SUSI.AI Skills</string>
-    <string name="error_skill_listing">Something went wrong. Please try again later.</string>
+    <string name="error_skill_listing">Unable to fetch skills. Something went wrong. Please try again later.</string>
+    <string name="no_skill_author">Skill Author not found</string>
     <string name="reset_password_message">Resetting Password..</string>
 </resources>


### PR DESCRIPTION
Fixes #902 

Implement skill details section when a skill is clicked. example 

Google assistant
.
<img src="https://user-images.githubusercontent.com/16978820/29520501-f03a1fc0-869e-11e7-947d-ea19155249f4.png" height = "480" width="270">

.
Skill cms
.
![screenshot from 2017-08-21 18 20 12](https://user-images.githubusercontent.com/16978820/29520502-f0402d34-869e-11e7-8799-9fd8344e6bb3.png)

.
<img src="https://user-images.githubusercontent.com/16978820/29992762-f72aaeb4-8fc0-11e7-915a-75e0235aa377.png" height = "480" width="270">

<img src="https://user-images.githubusercontent.com/16978820/29992763-f73310c2-8fc0-11e7-96cb-9396d6b4b5d0.png" height = "480" width="270">

Added a "Try it" button so that user can just try the skill on the chat interface.
