### PR TITLE
Fix: Show correct title in settings fragment

### DIFF
--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -23,7 +23,6 @@
         </activity>
         <activity
             android:name=".skills.SkillsActivity"
-            android:label="@string/skills_activity"
             android:theme="@style/PreferencesThemeLight"
             android:configChanges="orientation|screenSize">
             <meta-data

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,7 +21,6 @@
         android:theme="@style/AppTheme">
         <activity
             android:name=".skills.SkillsActivity"
-            android:label="@string/skills_activity"
             android:theme="@style/PreferencesThemeLight"
             android:configChanges="orientation|screenSize">
             <meta-data

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -57,6 +57,7 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
     override fun onCreatePreferences(savedInstanceState: Bundle?, rootKey: String?) {
         addPreferencesFromResource(R.xml.pref_settings)
 
+        (activity as SkillsActivity).title = (activity as SkillsActivity).getString(R.string.action_settings)
         settingsPresenter = SettingsPresenter(activity as SkillsActivity)
         settingsPresenter.onAttach(this)
 

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
@@ -10,6 +10,7 @@ import android.view.ViewGroup
 import kotlinx.android.synthetic.main.fragment_skill_listing.*
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
+import org.fossasia.susi.ai.skills.SkillsActivity
 import org.fossasia.susi.ai.skills.skilllisting.adapters.recycleradapters.SkillGroupAdapter
 import org.fossasia.susi.ai.skills.skilllisting.contract.ISkillListingPresenter
 import org.fossasia.susi.ai.skills.skilllisting.contract.ISkillListingView
@@ -29,6 +30,7 @@ class SkillListingFragment: Fragment(), ISkillListingView {
     }
 
     override fun onViewCreated(view: View?, savedInstanceState: Bundle?) {
+        (activity as SkillsActivity).title = (activity as SkillsActivity).getString(R.string.skills_activity)
         skillListingPresenter = SkillListingPresenter()
         skillListingPresenter.onAttach(this)
         setUPAdapter()


### PR DESCRIPTION
Fixes #909 

Screenshots for the change: 
 
<img src="https://user-images.githubusercontent.com/14003244/29772422-563fc1ae-8c16-11e7-9d4e-7935bb5a2f4c.png" height="420" width="280">
