### PR TITLE
fix: change dialog message in forgot password

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/forgotpassword/ForgotPasswordActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/forgotpassword/ForgotPasswordActivity.kt
@@ -47,7 +47,7 @@ class ForgotPasswordActivity : AppCompatActivity (), IForgotPasswordView {
 
         progressDialog = ProgressDialog(this)
         progressDialog.setCancelable(false)
-        progressDialog.setMessage(getString(R.string.login))
+        progressDialog.setMessage(getString(R.string.reset_password_message))
 
         showUrl()
         cancelRequestPassword()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -159,4 +159,5 @@
     <string name="skill_title">Skill Title</string>
     <string name="skills_activity">SUSI.AI Skills</string>
     <string name="error_skill_listing">Something went wrong. Please try again later.</string>
+    <string name="reset_password_message">Resetting Password..</string>
 </resources>


### PR DESCRIPTION
Fixes #914 

Changed message in dialog in forgot password activity from "logging in" to "Resetting Password"
