### PR TITLE
fix: Skills loading speed increased

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/data/SkillListingModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/SkillListingModel.kt
@@ -18,9 +18,11 @@ class SkillListingModel: ISkillListingModel {
     lateinit var authResponseCallGroups: Call<ListGroupsResponse>
     lateinit var authResponseCallSkills: Call<ListSkillsResponse>
 
+    var clientBuilder: ClientBuilder = ClientBuilder()
+
     override fun fetchGroups(listener: ISkillListingModel.onFetchGroupsFinishedListener) {
 
-        authResponseCallGroups = ClientBuilder().susiApi.fetchListGroups()
+        authResponseCallGroups = clientBuilder.susiApi.fetchListGroups()
 
         authResponseCallGroups.enqueue(object : Callback<ListGroupsResponse> {
             override fun onResponse(call: Call<ListGroupsResponse>, response: Response<ListGroupsResponse>) {
@@ -36,7 +38,7 @@ class SkillListingModel: ISkillListingModel {
 
     override fun fetchSkills(group: String, listener: ISkillListingModel.onFetchSkillsFinishedListener) {
 
-        authResponseCallSkills = ClientBuilder().susiApi.fetchListSkills(group)
+        authResponseCallSkills = clientBuilder.susiApi.fetchListSkills(group)
 
         authResponseCallSkills.enqueue(object : Callback<ListSkillsResponse> {
             override fun onResponse(call: Call<ListSkillsResponse>, response: Response<ListSkillsResponse>) {


### PR DESCRIPTION
This PR is in reference to [#613](https://github.com/fossasia/susi_android/issues/613). 

Changes: 
Earlier client builder was being built at every instance of skill listing call. Now, Client Builder is being initialized only once and the same object is used in each skill call. This has reduced the skill loading time to half.
