### PR TITLE
fix: Don't display empty skillgroups

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
@@ -52,8 +52,11 @@ class SkillListingPresenter: ISkillListingPresenter,
     override fun onSkillFetchSuccess(response: Response<ListSkillsResponse>, group: String) {
         skillListingView?.visibilityProgressBar(false)
         if (response.isSuccessful && response.body() != null) {
-            skills.add(Pair(group, response.body().skillMap))
-            skillListingView?.updateAdapter(skills)
+            val responseSkillMap = response.body().skillMap
+            if(responseSkillMap.isNotEmpty()) {
+                skills.add(Pair(group, responseSkillMap))
+                skillListingView?.updateAdapter(skills)
+            }
             count++
             if(count != groupsCount) {
                 skillListingModel.fetchSkills(groups[count], this)


### PR DESCRIPTION
Hide empty skillgroups

Fixes #968 

Changes: Hid the skill-group title and recyclerview if the group had no skills under it.

Screenshots for the change: 
<img src="https://user-images.githubusercontent.com/11333048/30786306-7ddf25ac-a191-11e7-99a1-1b5091d76729.png" width="250">