### PR TITLE
Added Ripple Effect in About Fragment

### DIFF
--- a/app/src/main/res/layout/fragment_about_us.xml
+++ b/app/src/main/res/layout/fragment_about_us.xml
@@ -21,7 +21,9 @@
             <android.support.v7.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:clickable="true">
+                android:clickable="true"
+                android:foreground="?attr/selectableItemBackground"
+                android:focusable="true">
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -54,7 +56,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_small"
-                android:clickable="true">
+                android:clickable="true"
+                android:foreground="?attr/selectableItemBackground"
+                android:focusable="true">
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -88,7 +92,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_small"
-                android:clickable="true">
+                android:clickable="true"
+                android:foreground="?attr/selectableItemBackground"
+                android:focusable="true">
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -122,7 +128,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_small"
-                android:clickable="true">
+                android:clickable="true"
+                android:foreground="?attr/selectableItemBackground"
+                android:focusable="true">
 
                 <LinearLayout
                     android:layout_width="match_parent"
@@ -157,7 +165,9 @@
                 android:layout_height="wrap_content"
                 android:layout_marginTop="@dimen/margin_small"
                 android:layout_marginBottom="@dimen/margin_medium"
-                android:clickable="true">
+                android:clickable="true"
+                android:foreground="?attr/selectableItemBackground"
+                android:focusable="true">
 
                 <LinearLayout
                     android:layout_width="match_parent"


### PR DESCRIPTION
Fixes #966

Changes: Added Ripple effect in all card views in about fragment

Screenshots for the change: 
![screenshot_1506307549](https://user-images.githubusercontent.com/18033231/30790493-d2bc22f4-a1c9-11e7-9f7b-9363e778a773.png)
