### PR TITLE
fix: Rename upload apk to correct file

### DIFF
--- a/exec/apk-gen.sh
+++ b/exec/apk-gen.sh
@@ -38,7 +38,7 @@ then
 	if [ "$CIRCLE_BRANCH" == "$PUBLISH_BRANCH" ]; then
 		echo "Publishing app to Play Store"
 		gem install fastlane
-		fastlane supply --apk test-app-release.apk --track alpha --json_key ../exec/fastlane.json --package_name $PACKAGE_NAME
+		fastlane supply --apk susi-release-signed.apk --track alpha --json_key ../exec/fastlane.json --package_name $PACKAGE_NAME
 	fi
 fi
 


### PR DESCRIPTION
Fixes #982

Changes:
- Rename upload file to `susi-release-signed.apk`