### PR TITLE
Fixed TTS not stopping when app goes to background

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
@@ -454,6 +454,8 @@ class ChatActivity: AppCompatActivity(), IChatView {
         if (recordingThread != null)
             chatPresenter.stopHotwordDetection()
 
+        textToSpeech.stop()
+
     }
 
     override fun onDestroy() {


### PR DESCRIPTION
Fixes #989 
Changes: Fixed TextToSpeech not stopping when app goes to background.
