### PR TITLE
fix: Backbutton press in SkillsActivity

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
@@ -32,8 +32,9 @@ class SkillsActivity : AppCompatActivity() {
         setContentView(R.layout.activity_skills)
 
         val skillFragment = SkillListingFragment()
-        fragmentManager.beginTransaction()
+        supportFragmentManager.beginTransaction()
                 .add(R.id.fragment_container, skillFragment, TAG_SKILLS_FRAGMENT)
+                .addToBackStack(TAG_SKILLS_FRAGMENT)
                 .commit()
     }
 
@@ -52,24 +53,18 @@ class SkillsActivity : AppCompatActivity() {
 
     override fun onBackPressed() {
         overridePendingTransition(R.anim.trans_right_in, R.anim.trans_right_out)
-        val fragment = fragmentManager.findFragmentById(R.id.fragment_container)
-
-        when(fragment){
-            is SkillDetailsFragment ->  {
-                fragmentManager.popBackStack()
-                title = getString(R.string.skills_activity)
-            }
-            else -> {
-               finish()
-               exitActivity()
-            }
+        if (supportFragmentManager.popBackStackImmediate(TAG_SKILLS_FRAGMENT, 0)) {
+            title = getString(R.string.skills_activity)
+        } else {
+            finish()
+            exitActivity()
         }
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             android.R.id.home -> {
-               onBackPressed()
+                onBackPressed()
                 return true
             }
 
@@ -77,13 +72,15 @@ class SkillsActivity : AppCompatActivity() {
                 val settingsFragment = ChatSettingsFragment()
                 supportFragmentManager.beginTransaction()
                         .add(R.id.fragment_container, settingsFragment, TAG_SETTINGS_FRAGMENT)
+                        .addToBackStack(TAG_SETTINGS_FRAGMENT)
                         .commit()
             }
 
             R.id.menu_about -> {
                 val aboutFragment = AboutUsFragment()
                 supportFragmentManager.beginTransaction()
-                        .add(R.id.fragment_container,aboutFragment,TAG_ABOUT_FRAGMENT)
+                        .add(R.id.fragment_container, aboutFragment, TAG_ABOUT_FRAGMENT)
+                        .addToBackStack(TAG_ABOUT_FRAGMENT)
                         .commit()
             }
         }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -1,6 +1,6 @@
 package org.fossasia.susi.ai.skills.skilldetails
 
-import android.app.Fragment
+import android.support.v4.app.Fragment
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
@@ -1,6 +1,6 @@
 package org.fossasia.susi.ai.skills.skilllisting
 
-import android.app.Fragment
+import android.support.v4.app.Fragment
 import android.os.Bundle
 import android.support.v7.widget.LinearLayoutManager
 import android.view.LayoutInflater

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
@@ -64,9 +64,9 @@ class SkillListAdapter(val context: Context, val skillDetails:  Pair<String, Map
 
     fun showSkillDetailFragment(skillData: SkillData, skillGroup: String) {
         val skillDetailsFragment = SkillDetailsFragment.newInstance(skillData,skillGroup)
-        (context as SkillsActivity).fragmentManager.beginTransaction()
+        (context as SkillsActivity).supportFragmentManager.beginTransaction()
                 .add(R.id.fragment_container, skillDetailsFragment)
-                .addToBackStack(SkillListingFragment().toString())
+                .addToBackStack(SkillDetailsFragment().toString())
                 .commit()
     }
 


### PR DESCRIPTION
Fixes #995 

Changes: 

AboutUsFragment and ChatSettingsFragment both inherited from android.support.v4.app.Fragment, whereas SkillDetailsFragment and SkillListingFragment use android.app.Fragment. This was causing problems with the fragment manager stack. So, for uniformity, changed everything to use the compatibility library.

Now, on pressing back, everything goes back to the skill listing fragment.