### PR TITLE
fix: Display placeholder img for broken skill images

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -75,6 +75,7 @@ class SkillDetailsFragment: Fragment() {
         if(skillData.image != null && !skillData.image.isEmpty()){
             Picasso.with(activity.applicationContext).load(StringBuilder(imageLink)
                     .append(skillGroup).append("/en/").append(skillData.image).toString())
+                    .error(R.drawable.ic_susi)
                     .fit().centerCrop()
                     .into(skill_detail_image)
         }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
@@ -48,6 +48,7 @@ class SkillListAdapter(val context: Context, val skillDetails:  Pair<String, Map
             Picasso.with(context.applicationContext).load(StringBuilder(imageLink)
                     .append(skillDetails.first.replace(" ","%20")).append("/en/").append(skillData.image).toString())
                     .fit().centerCrop()
+                    .error(R.drawable.ic_susi)
                     .into(holder?.previewImageView)
         }
     }


### PR DESCRIPTION
Fixes #981 

Changes: 
Made Picasso load up the placeholder image in case of error.

Screenshots for the change: 
<img src="https://user-images.githubusercontent.com/11333048/30827682-962ce46a-a258-11e7-8df8-4907bba3801e.png" width="250">   <img src="https://user-images.githubusercontent.com/11333048/30827683-964ad808-a258-11e7-93f2-81b5387c6f9f.png" width="250">
This is how it looked after this change, before [this](https://github.com/fossasia/susi_skill_data/pull/303) got pulled in. The placeholder images get loaded for the broken links.

Now we have the actual images:
<img src="https://user-images.githubusercontent.com/11333048/30959388-96ecae56-a45d-11e7-9edc-99d319d17f23.png" width="250">