### PR TITLE
chore: Force copy and align  apks while signing

### DIFF
--- a/exec/apk-gen.sh
+++ b/exec/apk-gen.sh
@@ -17,9 +17,9 @@ then
 	# Signing App
 	if [ "$CIRCLE_BRANCH" == "$PUBLISH_BRANCH" ]; then
 		echo "Push to master branch detected, signing the app..."
-		cp susi-release.apk susi-release-unaligned.apk
+		\cp susi-release.apk susi-release-unaligned.apk
 		jarsigner -verbose -tsa http://timestamp.comodoca.com/rfc3161 -sigalg SHA1withRSA -digestalg SHA1 -keystore ../exec/key.jks -storepass $STORE_PASS -keypass $KEY_PASS susi-release-unaligned.apk $ALIAS
-		${ANDROID_HOME}/build-tools/25.0.2/zipalign -v -p 4 susi-release-unaligned.apk susi-release-signed.apk
+		${ANDROID_HOME}/build-tools/25.0.2/zipalign -vfp 4 susi-release-unaligned.apk susi-release-signed.apk
 	fi
 
 	git checkout --orphan workaround


### PR DESCRIPTION
Fixes #999

Changes: 
- Force copy apk while generation
- Overwrite output file while ziplaligning


Reference : https://developer.android.com/studio/command-line/zipalign.html