### PR TITLE
fix: Do not concatenate strings in loop

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
@@ -124,10 +124,8 @@ class ChatActivity: AppCompatActivity(), IChatView {
                     btnSpeak.setOnClickListener ({
                         chatPresenter.check(false)
                         val chat_message = et_message.text.toString().trim({ it <= ' ' })
-                        val splits = chat_message.split("\n".toRegex()).dropLastWhile({ it.isEmpty() }).toTypedArray()
-                        var message = ""
-                        for (split in splits)
-                            message = message + split + " "
+                        val splits = chat_message.split("\n".toRegex()).dropLastWhile({ it.isEmpty() })
+                        val message = splits.joinToString(" ")
                         if (!chat_message.isEmpty()) {
                             chatPresenter.sendMessage(message, et_message.text.toString())
                             et_message.setText("")


### PR DESCRIPTION
This PR is reference to #613.

Changes: Use builtin joinToString method instead of concatenating strings in loop at https://github.com/fossasia/susi_android/blob/development/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt#L130