### PR TITLE
feat: Add share button to SkillDetailsFragment

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -18,6 +18,7 @@ import org.fossasia.susi.ai.rest.responses.susi.SkillData
 import org.fossasia.susi.ai.skills.SkillsActivity
 import org.fossasia.susi.ai.skills.skilldetails.adapters.recycleradapters.SkillExamplesAdapter
 import java.io.Serializable
+import android.net.Uri
 
 /**
  *
@@ -27,16 +28,19 @@ class SkillDetailsFragment: Fragment() {
 
     lateinit var skillData: SkillData
     lateinit var skillGroup: String
+    lateinit var skillTag: String
     val imageLink = "https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/general/"
 
     companion object {
         val SKILL_KEY = "skill_key"
+        val SKILL_TAG = "skill_tag"
         val SKILL_GROUP = "skill_group"
-        fun newInstance(skillData: SkillData, skillGroup: String): SkillDetailsFragment {
+        fun newInstance(skillData: SkillData, skillGroup: String, skillTag: String): SkillDetailsFragment {
             val fragment = SkillDetailsFragment()
             val bundle = Bundle()
             bundle.putSerializable(SKILL_KEY, skillData as Serializable)
             bundle.putString(SKILL_GROUP, skillGroup)
+            bundle.putString(SKILL_TAG, skillTag)
             fragment.arguments = bundle
 
             return fragment
@@ -47,6 +51,7 @@ class SkillDetailsFragment: Fragment() {
         skillData = arguments.getSerializable(
                 SKILL_KEY) as SkillData
         skillGroup = arguments.getString(SKILL_GROUP)
+        skillTag = arguments.getString(SKILL_TAG)
         return inflater.inflate(R.layout.fragment_skill_details, container, false)
     }
 
@@ -62,6 +67,7 @@ class SkillDetailsFragment: Fragment() {
         setName()
         setAuthor()
         setTryButton()
+        setShareButton()
         setDescription()
         setExamples()
         setRating()
@@ -119,6 +125,27 @@ class SkillDetailsFragment: Fragment() {
                 intent.putExtra("example","")
             startActivity(intent)
             activity.finish()
+        }
+    }
+
+    fun setShareButton() {
+        if(skillTag == null || skillTag.isEmpty()) {
+            skill_detail_share_button.visibility = View.GONE
+            return
+        }
+
+        skill_detail_share_button.setOnClickListener {
+            val shareUriBuilder = Uri.Builder()
+            shareUriBuilder.scheme("https")
+                    .authority("skills.susi.ai")
+                    .appendPath(skillGroup)
+                    .appendPath(skillTag)
+                    .appendPath("en")
+            val sendIntent = Intent()
+            sendIntent.action = Intent.ACTION_SEND
+            sendIntent.putExtra(Intent.EXTRA_TEXT, shareUriBuilder.build().toString())
+            sendIntent.type = "text/plain"
+            context.startActivity(sendIntent)
         }
     }
 

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
@@ -58,13 +58,14 @@ class SkillListAdapter(val context: Context, val skillDetails:  Pair<String, Map
     }
 
     override fun onItemClicked(position: Int) {
+        val skillTag = skillDetails.second.keys.toTypedArray()[position]
         val skillData = skillDetails.second.values.toTypedArray()[position]
         val skillGroup = skillDetails.first.replace(" ","%20")
-        showSkillDetailFragment(skillData, skillGroup)
+        showSkillDetailFragment(skillData, skillGroup, skillTag)
     }
 
-    fun showSkillDetailFragment(skillData: SkillData, skillGroup: String) {
-        val skillDetailsFragment = SkillDetailsFragment.newInstance(skillData,skillGroup)
+    fun showSkillDetailFragment(skillData: SkillData, skillGroup: String, skillTag: String) {
+        val skillDetailsFragment = SkillDetailsFragment.newInstance(skillData, skillGroup, skillTag)
         (context as SkillsActivity).supportFragmentManager.beginTransaction()
                 .add(R.id.fragment_container, skillDetailsFragment)
                 .addToBackStack(SkillDetailsFragment().toString())

--- a/app/src/main/res/layout/fragment_skill_details.xml
+++ b/app/src/main/res/layout/fragment_skill_details.xml
@@ -66,6 +66,20 @@
                 android:textColor="@color/md_white_1000"
                 android:layout_marginRight="16dp"
                 android:layout_marginBottom="16dp"/>
+            <Button
+                android:id="@+id/skill_detail_share_button"
+                android:layout_width="100dp"
+                android:layout_height="40dp"
+                android:text="@string/action_share"
+                android:drawableLeft="@drawable/ic_share_white_24dp"
+                android:drawableStart="@drawable/ic_share_white_24dp"
+                android:drawableTint="@color/md_white_1000"
+                android:padding="10dp"
+                android:layout_marginTop="8dp"
+                android:background="@color/colorPrimary"
+                android:textColor="@color/md_white_1000"
+                android:layout_marginRight="16dp"
+                android:layout_marginBottom="16dp"/>
         </LinearLayout>
 
         <LinearLayout


### PR DESCRIPTION
Fixes #1028

Changes: 
Added a share button to SkillDetailsFragment to share a URI to the skill.

Screenshots for the change: 
<img src="https://user-images.githubusercontent.com/11333048/31629600-c7aa4350-b2d1-11e7-8984-028eab700931.png" width="300">