### PR TITLE
Collect lint and tests reports

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -17,12 +17,24 @@ test:
         - emulator -avd circleci-android22 -no-audio -no-window:
             background: true
             parallel: true
-        # wait for it to have booted
+        
+        # Wait for it to have booted
         - circle-android wait-for-boot
-        # run tests  against the emulator.
+        
+        # Tun tests  against the emulator.
         - ./gradlew connectedCheck
-       # - cd exec
-       # - ls
+        
+        # Run Lint
+        - ./gradlew lint
+        
+        # Copy lint report
+        - mkdir $CIRCLE_TEST_REPORTS/Lint
+        - cp app/build/reports/lint-results.* $CIRCLE_TEST_REPORTS/Lint
+
+        # Copy tests report
+        - mkdir $CIRCLE_TEST_REPORTS/AndroidTests
+        - cp -r app/build/reports/androidTests/connected/* $CIRCLE_TEST_REPORTS/AndroidTests
+
         - bash exec/prep-key.sh
         - chmod +x exec/apk-gen.sh
         - ./exec/apk-gen.sh


### PR DESCRIPTION
Fixes #655 

Changes: Add Lint and Tests reports to CircleCI Artifact to be able to check them after the build process
