### PR TITLE
Fixes #1071: Update dependency configurations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,53 +52,53 @@ android {
 }
 
 dependencies {
-    compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile "com.android.support:appcompat-v7:${rootConfiguration.supportLibraryVersion}"
-    compile "com.android.support:recyclerview-v7:${rootConfiguration.supportLibraryVersion}"
-    compile "com.android.support:design:${rootConfiguration.supportLibraryVersion}"
-    compile "com.android.support:cardview-v7:${rootConfiguration.supportLibraryVersion}"
-    compile "com.android.support:support-v4:${rootConfiguration.supportLibraryVersion}"
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation "com.android.support:appcompat-v7:${rootConfiguration.supportLibraryVersion}"
+    implementation "com.android.support:recyclerview-v7:${rootConfiguration.supportLibraryVersion}"
+    implementation "com.android.support:design:${rootConfiguration.supportLibraryVersion}"
+    implementation "com.android.support:cardview-v7:${rootConfiguration.supportLibraryVersion}"
+    implementation "com.android.support:support-v4:${rootConfiguration.supportLibraryVersion}"
 
     //piechart
-    compile "com.github.PhilJay:MPAndroidChart:${rootConfiguration.mpAndroidChartVersion}"
+    implementation "com.github.PhilJay:MPAndroidChart:${rootConfiguration.mpAndroidChartVersion}"
 
     //Leak Canary
-    debugCompile "com.squareup.leakcanary:leakcanary-android:${rootConfiguration.leakCanaryVersion}"
-    releaseCompile "com.squareup.leakcanary:leakcanary-android-no-op:${rootConfiguration.leakCanaryVersion}"
-    testCompile "com.squareup.leakcanary:leakcanary-android-no-op:${rootConfiguration.leakCanaryVersion}"
+    debugImplementation "com.squareup.leakcanary:leakcanary-android:${rootConfiguration.leakCanaryVersion}"
+    releaseImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${rootConfiguration.leakCanaryVersion}"
+    testImplementation "com.squareup.leakcanary:leakcanary-android-no-op:${rootConfiguration.leakCanaryVersion}"
 
     //butterknife
-    compile "com.jakewharton:butterknife:${rootConfiguration.butterKnifeVersion}"
+    implementation "com.jakewharton:butterknife:${rootConfiguration.butterKnifeVersion}"
     kapt "com.jakewharton:butterknife-compiler:${rootConfiguration.butterKnifeVersion}"
 
     //For Picasso
-    compile "com.squareup.picasso:picasso:${rootConfiguration.picassoVersion}"
+    implementation "com.squareup.picasso:picasso:${rootConfiguration.picassoVersion}"
 
     //Retrofit
-    compile "com.squareup.retrofit2:retrofit:${rootConfiguration.retrofitVersion}"
-    compile "com.squareup.retrofit2:converter-gson:${rootConfiguration.retrofitVersion}"
-    debugCompile "com.squareup.okhttp3:logging-interceptor:${rootConfiguration.okHttpVersion}"
+    implementation "com.squareup.retrofit2:retrofit:${rootConfiguration.retrofitVersion}"
+    implementation "com.squareup.retrofit2:converter-gson:${rootConfiguration.retrofitVersion}"
+    debugImplementation "com.squareup.okhttp3:logging-interceptor:${rootConfiguration.okHttpVersion}"
 
     //For Link Previews
-    compile "org.jsoup:jsoup:${rootConfiguration.jsoupVersion}" // required
-    compile "com.leocardz:link-preview:${rootConfiguration.linkPreviewVersion}"
+    implementation "org.jsoup:jsoup:${rootConfiguration.jsoupVersion}" // required
+    implementation "com.leocardz:link-preview:${rootConfiguration.linkPreviewVersion}"
 
     //preference UI
-    compile "com.takisoft.fix:preference-v7:${rootConfiguration.preferenceVersion}"
+    implementation "com.takisoft.fix:preference-v7:${rootConfiguration.preferenceVersion}"
 
     //unit test
-    androidTestCompile "com.android.support:support-annotations:${rootConfiguration.supportLibraryVersion}"
-    androidTestCompile "com.android.support.test:runner:${rootConfiguration.testVersion}"
-    androidTestCompile "com.android.support.test:rules:${rootConfiguration.testVersion}"
-    androidTestCompile "com.android.support.test.espresso:espresso-core:${rootConfiguration.espressoVersion}"
+    androidTestImplementation "com.android.support:support-annotations:${rootConfiguration.supportLibraryVersion}"
+    androidTestImplementation "com.android.support.test:runner:${rootConfiguration.testVersion}"
+    androidTestImplementation "com.android.support.test:rules:${rootConfiguration.testVersion}"
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:${rootConfiguration.espressoVersion}"
 
     //realm adapter
-    compile "io.realm:android-adapters:${rootConfiguration.realmVersion}"
+    implementation "io.realm:android-adapters:${rootConfiguration.realmVersion}"
 
     //waiting dots
-    compile "com.github.tajchert:WaitingDots:${rootConfiguration.waitingDotsVersion}"
-    compile("com.crashlytics.sdk.android:crashlytics:${rootConfiguration.crashlyticsVersion}") {
+    implementation "com.github.tajchert:WaitingDots:${rootConfiguration.waitingDotsVersion}"
+    implementation("com.crashlytics.sdk.android:crashlytics:${rootConfiguration.crashlyticsVersion}") {
         transitive = true
     }
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:${rootConfiguration.kotlinVersion}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:${rootConfiguration.kotlinVersion}"
 }

--- a/app/config.gradle
+++ b/app/config.gradle
@@ -1,6 +1,6 @@
 ext {
     compileSdkVersion = 25
-    buildToolsVersion = "25.0.2"
+    buildToolsVersion = "26.0.2"
     minSdkVersion = 15
     targetSdkVersion = 25
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,9 +4,10 @@ buildscript {
     repositories {
         jcenter()
         mavenCentral()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath "io.realm:realm-gradle-plugin:3.5.0"

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@
 dependencies:
     override:
         - ( sleep 5 && while [ 1 ]; do sleep 1; echo y; done ) | android update sdk --no-ui --all --filter "tools,platform-tools,android-25,extra-google-m2repository,extra-android-m2repository,extra-android-support,extra-google-google_play_services"
-        - echo y | android update sdk --no-ui --all --filter "build-tools-25.0.2"
+        - echo y | android update sdk --no-ui --all --filter "build-tools-26.0.2"
         - ANDROID_HOME=/usr/local/android-sdk-linux ./gradlew dependencies
 
 #Pull any submodules

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue May 02 22:30:08 IST 2017
+#Tue Dec 12 15:49:37 IST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Fixes #1071 

Changes: 

Replacements:
`compile` -> `implementation`
`debugCompile` -> `debugImplementation`
`testCompile` -> `testImplementation`
`androidTestCompile` -> `androidTestImplementation`
`releaseCompile` -> `releaseImplementation`

To obtain the above updates:

- Upgraded Android Gradle Plugin to `v3.0.1`

- Upgraded Gradle to `v4.1`

- Updated `circle.yml` file to support `buildToolsVersion = "26.0.2"`
