### PR TITLE
Fix #1085 enable auto capitalisation of the first letter of a sentence

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
@@ -331,7 +331,6 @@ class ChatActivity: AppCompatActivity(), IChatView {
     override fun checkEnterKeyPref(isChecked: Boolean) {
         if (isChecked) {
             et_message.imeOptions = EditorInfo.IME_ACTION_SEND
-            et_message.inputType = InputType.TYPE_CLASS_TEXT
         } else {
             et_message.imeOptions = EditorInfo.IME_FLAG_NO_ENTER_ACTION
         }

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -89,7 +89,7 @@
                             android:imeOptions="actionSend"
                             android:cursorVisible="true"
                             android:textCursorDrawable="@null"
-                            android:inputType="text"
+                            android:inputType="textCapSentences"
                             android:scrollbars="vertical"
                             android:theme="@style/sendMessageEditTextTheme" />
                     </FrameLayout>


### PR DESCRIPTION
Fixes #1085 

Changes: Auto capitalisation has been enabled for the first letter of a sentence

Screenshots for the change: 
![ezgif com-video-to-gif 29](https://user-images.githubusercontent.com/20878145/34513159-bcf899a4-f08c-11e7-8273-91c010f2a899.gif)
