### PR TITLE
Upgraded Kotlin Runtime Version to 1.1.51

### DIFF
--- a/app/config.gradle
+++ b/app/config.gradle
@@ -21,6 +21,6 @@ ext {
     waitingDotsVersion = '0.3.2'
     espressoVersion = '3.0.1'
     testVersion = '1.0.1'
-    kotlinVersion = '1.1.3'
+    kotlinVersion = '1.1.51'
     picassoVersion = '2.5.2'
 }


### PR DESCRIPTION
First Steps for issue #1094
Changes: changed the kotlin runtime version in config.gradle
Seems to remove the Outdated Kotlin Runtime warning in Android Studio
Runs the application properly in Android Studio version 3.0.1
  