### PR TITLE
Fix #1106 : Skill fetch error message overlapping the skill groups

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
@@ -60,6 +60,7 @@ class SkillListingFragment: Fragment(), ISkillListingView, SwipeRefreshLayout.On
     override fun displayError() {
         if(activity != null) {
             swipe_refresh_layout.isRefreshing = false
+            skillGroups.visibility = View.GONE;
             error_skill_fetch.visibility = View.VISIBLE
         }
     }

--- a/app/src/main/res/layout/fragment_skill_listing.xml
+++ b/app/src/main/res/layout/fragment_skill_listing.xml
@@ -24,6 +24,7 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="center"
+        android:gravity="center_horizontal"
         android:text="@string/error_skill_listing"
         android:textSize="18sp"
         android:padding="16dp"


### PR DESCRIPTION
Added necessary code to make the skill groups invisible while the
skill fetch error message is being displayed. This makes the error
message clear to the user and also makes the screen look cleaner.

Fixes #1106 

**Screenshots for the change:**

Before :
 
![error_skill_fetch_1](https://user-images.githubusercontent.com/30979369/36228052-09ce0330-11f9-11e8-8ce9-1716c2ed3ab3.jpg)

After : 

![error_skill_fetch_22](https://user-images.githubusercontent.com/30979369/36228002-e3c525ce-11f8-11e8-9a8e-606afc965896.jpg)
