### PR TITLE
Fixed Issue 1110 and 1080

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -264,7 +264,8 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
         val intent = Intent(activity, LoginActivity::class.java)
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(intent)
-        activity.finish()
+        //TODO Fixed issue 1080
+//        activity.finish()
     }
 
     fun showToast(message: String) {

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
@@ -59,7 +59,8 @@ class SkillListingPresenter: ISkillListingPresenter,
                 skills.add(Pair(group, responseSkillMap))
                 skillListingView?.updateAdapter(skills)
             }
-            //TODO issue incrementing count before using it that is why it was going out of index exception an dit was never getting the 0th index of the group
+            //TODO issue incrementing count before using it that
+            // is why it was going out of index exception an dit was never getting the 0th index of the group
 //            count++
             if(count != groupsCount) {
                //TODO Fixed variable count

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
@@ -1,5 +1,6 @@
 package org.fossasia.susi.ai.skills.skilllisting
 
+import android.util.Log
 import org.fossasia.susi.ai.data.SkillListingModel
 import org.fossasia.susi.ai.data.contract.ISkillListingModel
 import org.fossasia.susi.ai.rest.responses.susi.ListGroupsResponse
@@ -53,13 +54,16 @@ class SkillListingPresenter: ISkillListingPresenter,
         skillListingView?.visibilityProgressBar(false)
         if (response.isSuccessful && response.body() != null) {
             val responseSkillMap = response.body().skillMap
+            print(response.body().skillMap.size)
             if(responseSkillMap.isNotEmpty()) {
                 skills.add(Pair(group, responseSkillMap))
                 skillListingView?.updateAdapter(skills)
             }
-            count++
+            //TODO issue incrementing count before using it that is why it was going out of index exception an dit was never getting the 0th index of the group
+//            count++
             if(count != groupsCount) {
-                skillListingModel.fetchSkills(groups[count], this)
+               //TODO Fixed variable count
+                skillListingModel.fetchSkills(groups[count++], this)
             }
         } else {
             skillListingView?.visibilityProgressBar(false)


### PR DESCRIPTION
Fixes #1110 
Fixes #1080 
@mariobehling @chiragw15 
Changes: #1110  The variable 'count' in SkillListingPresenter.kt file was incremented before it was used which is why it was causing array out of bonds exception.
#1080 The ChatSettingsFragment.kt was finishing after starting the login activity.

Screenshots for the change: 
#1110 
<img width="800" alt="screen shot 2018-02-17 at 2 18 12 am" src="https://user-images.githubusercontent.com/12862333/36338968-0e01fb96-1389-11e8-9b55-2494e3178f45.png">
#1080
<img width="699" alt="screen shot 2018-02-17 at 2 46 40 am" src="https://user-images.githubusercontent.com/12862333/36339152-d8a52528-138c-11e8-8e5c-ab4cc2f22e9c.png">


