### PR TITLE
Corrected the colors associated with positive and negative ratings (Fixed #1117)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -190,7 +190,7 @@ class SkillDetailsFragment: Fragment() {
         var resId = R.color.colorAccent
         if (rating != null) {
             when (s) {
-                "Positive" ->
+                "Negative" ->
                         if (rating < 10)
                             resId = R.color.md_red_100
                         else if (rating in 10..19)
@@ -203,7 +203,7 @@ class SkillDetailsFragment: Fragment() {
                             resId = R.color.md_red_300
                         else
                             resId = R.color.md_red_400
-                "Negative" ->
+                "Positive" ->
                     if (rating < 10)
                         resId = R.color.md_blue_100
                     else if (rating in 10..19)


### PR DESCRIPTION
Earlier the colors for positive and negative ratings were interchanged
in actual device though the android studio preview displayed them
correctly. This happened because of the interchanged strings labels
"Positive" and "Negative" in getRatedColor function in SkillDetailsFragment.kt

Fixes #1117 

**Screenshots for the change:**

Before :

![opposite_thumbs_issue](https://user-images.githubusercontent.com/30979369/36632543-ceedc7ca-19ad-11e8-82e2-156497c4c76c.png)

After :

![opposite_thumbs_issue_fixed](https://user-images.githubusercontent.com/30979369/36632553-f1556afc-19ad-11e8-9b04-7a0989acc71e.png)

On actual device : 

Device used : Xiaomi Redmi Note 4

![opposite_thumbs_actual_device](https://user-images.githubusercontent.com/30979369/36632576-32e17b0a-19ae-11e8-9ca9-d62574547fad.jpg)
