### PR TITLE
Fix #1145-Search option hidden in the About us Fragment.

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -27,7 +27,9 @@ class AboutUsFragment : Fragment() {
         val itemAbout = menu.findItem(R.id.menu_about)
         itemAbout.isVisible = false
         val itemSettings = menu.findItem(R.id.menu_settings)
-        itemSettings.isVisible= true;
+        itemSettings.isVisible= true
+        var searchoption = menu.findItem(R.id.action_search)
+        searchoption.isVisible = false;
         super.onPrepareOptionsMenu(menu)
     }
 


### PR DESCRIPTION
Fixes #1145 
Changes: Search icon no longer visible in the About Us Fragment.

Screenshots for the change: 
![screenshot_2018-03-01-23-55-37-113_ai susi](https://user-images.githubusercontent.com/20841578/36862265-57c3b7c4-1dac-11e8-8351-44cbe4d5111e.png)
