### PR TITLE
Fixes #1149 -Added confirmation before exit on the login screen.

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
@@ -4,6 +4,8 @@ import android.app.ProgressDialog
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
+import android.os.Handler
+import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
 import android.view.View
 import android.view.inputmethod.EditorInfo
@@ -173,5 +175,26 @@ class LoginActivity : AppCompatActivity(), ILoginView {
     override fun onDestroy() {
         loginPresenter.onDetach()
         super.onDestroy()
+    }
+
+/**
+ * To confirm before exiting the app.
+ * Created by ujjwalagr on 02/03/18.
+ */
+
+    var doubleBackToExitPressedOnce = false
+    override fun onBackPressed() {
+        if (doubleBackToExitPressedOnce)
+        {
+            super.onBackPressed()
+            return
+        }
+        this.doubleBackToExitPressedOnce = true
+        Toast.makeText(this, "Please click BACK again to exit", Toast.LENGTH_SHORT).show()
+        Handler().postDelayed(object:Runnable {
+            public override fun run() {
+                doubleBackToExitPressedOnce = false
+            }
+        }, 2000)
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
@@ -190,7 +190,7 @@ class LoginActivity : AppCompatActivity(), ILoginView {
             return
         }
         this.doubleBackToExitPressedOnce = true
-        Toast.makeText(this, "Please click BACK again to exit", Toast.LENGTH_SHORT).show()
+        Toast.makeText(this, "Press again to exit", Toast.LENGTH_SHORT).show()
         Handler().postDelayed(object:Runnable {
             public override fun run() {
                 doubleBackToExitPressedOnce = false


### PR DESCRIPTION
**Fixes** #1149  -Added confirmation before exit.

**Changes:**
 1. Updated LoginActivity.kt  overriding the back button pressed function and added confirmation before exit when user is (logging in) in the app.
 2. Added Toast that confirm the exit status at the login activity.

Previous Behaviour
![whatsapp-video-2018-03-02-at-10 01 57-pm](https://user-images.githubusercontent.com/23070301/36912910-4115510a-1e6e-11e8-8403-18b592cd1ddc.gif)

After Updation
![whatsapp-video-2018-03-02-at-9 57 30-pm](https://user-images.githubusercontent.com/23070301/36912924-4dd49b9e-1e6e-11e8-9ef0-dfb9146aba01.gif)

