### PR TITLE
Fixes #1149 -Added confirmation before exit on the login screen

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
@@ -4,6 +4,8 @@ import android.app.ProgressDialog
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
+import android.os.Handler
+import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
 import android.view.View
 import android.view.inputmethod.EditorInfo
@@ -173,5 +175,26 @@ class LoginActivity : AppCompatActivity(), ILoginView {
     override fun onDestroy() {
         loginPresenter.onDetach()
         super.onDestroy()
+    }
+
+/**
+ * To confirm before exiting the app.
+ * Created by ujjwalagr on 02/03/18.
+ */
+
+    var doubleBackToExitPressedOnce = false
+    override fun onBackPressed() {
+        if (doubleBackToExitPressedOnce)
+        {
+            super.onBackPressed()
+            return
+        }
+        this.doubleBackToExitPressedOnce = true
+        Toast.makeText(this, "Press again to exit", Toast.LENGTH_SHORT).show()
+        Handler().postDelayed(object:Runnable {
+            public override fun run() {
+                doubleBackToExitPressedOnce = false
+            }
+        }, 2000)
     }
 }


### PR DESCRIPTION
Fixes #1149   -Added confirmation before exit on Login Screen

**Changes:**

    1.Updated LoginActivity.kt overriding the back button pressed function and added 
       confirmation  before exit when user is (logging in) in the app.
    2. Added Toast that confirm the exit status at the login activity.

**Previously**

![whatsapp-video-2018-03-02-at-10 01 57-pm](https://user-images.githubusercontent.com/23070301/36936914-8985bede-1f31-11e8-8be1-98e13a23663c.gif)

**After Updates**

![whatsapp-video-2018-03-02-at-9 57 30-pm](https://user-images.githubusercontent.com/23070301/36936929-a3264732-1f31-11e8-90ae-aaac57b13936.gif)

**Note**

Toast will display "press again to exit". The gif displayed is not updated accordingly but the issue is fixed.You can see the updates in the code below.

![screenshot from 2018-03-03 22-25-45](https://user-images.githubusercontent.com/23070301/36936946-da6b9fb2-1f31-11e8-94c3-677dbc4fb857.png)
