### PR TITLE
Fix #1129-Dialog issue resolved.

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/helper/AlertboxHelper.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/AlertboxHelper.kt
@@ -37,7 +37,7 @@ class AlertboxHelper
     fun showAlertBox() {
         val alertDialog = AlertDialog.Builder(activity)
         alertDialog.setTitle(title)
-        alertDialog.setCancelable(false)
+        alertDialog.setCancelable(true)
         alertDialog.setMessage(message)
         alertDialog.setPositiveButton(positiveText, dialogPositiveClick)
         alertDialog.setNeutralButton(negativeText, dialogNegativeClick)

--- a/app/src/main/java/org/fossasia/susi/ai/signup/SignUpActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/signup/SignUpActivity.kt
@@ -79,13 +79,12 @@ class SignUpActivity : AppCompatActivity(), ISignUpView {
     }
 
     override fun onBackPressed() {
-        val alertDialog = AlertDialog.Builder(this@SignUpActivity)
-        alertDialog.setCancelable(false)
-        alertDialog.setMessage(R.string.error_cancelling_signUp_process_text)
-        alertDialog.setPositiveButton(R.string.yes) { _, _ -> super@SignUpActivity.onBackPressed() }
-        alertDialog.setNegativeButton((R.string.no), null)
-        val alert = alertDialog.create()
-        alert.show()
+        val dialogClickListener = DialogInterface.OnClickListener { _, _ -> super@SignUpActivity.onBackPressed() }
+        val alertMessage = getString(R.string.error_cancelling_signUp_process_text)
+        val successAlertboxHelper = AlertboxHelper(this@SignUpActivity, null, alertMessage, dialogClickListener, null,
+                resources.getString(R.string.yes), resources.getString(R.string.continue_sign_up), resources.getColor(R.color
+                .md_blue_500))
+        successAlertboxHelper.showAlertBox()
     }
 
     override fun alertSuccess() {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -165,6 +165,8 @@
     <string name="unknown_answer">I don\'t know.</string>
 
     <!-- Login Activity-->
+    <string name="continue_sign_up">Continue Registration</string>
+
     <string name="email_invalid_title">Incorrect e-mail address</string>
 
     <string name="first_time">First time</string>


### PR DESCRIPTION
Fixes #1129

Changes: The reset password dialog is dismissed on tapping on the screen or on pressing the back navigation button, the AlertboxHelper class is now used for displaying the alert dialog to cancel the sign up process.
