### PR TITLE
Retain scroll position of chat feed on configuration change

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
@@ -8,6 +8,7 @@ import android.Manifest
 import android.app.ProgressDialog
 import android.content.*
 import android.content.pm.PackageManager
+import android.content.res.Configuration
 import android.media.AudioManager
 import android.net.ConnectivityManager
 import android.os.*
@@ -60,6 +61,7 @@ class ChatActivity: AppCompatActivity(), IChatView {
     lateinit var networkStateReceiver: BroadcastReceiver
     lateinit var progressDialog: ProgressDialog
     var example: String = ""
+    var isConfigurationChanged = false
 
     val afChangeListener = AudioManager.OnAudioFocusChangeListener { focusChange ->
         if (focusChange == AudioManager.AUDIOFOCUS_LOSS_TRANSIENT || focusChange == AudioManager.AUDIOFOCUS_LOSS) {
@@ -166,6 +168,11 @@ class ChatActivity: AppCompatActivity(), IChatView {
         })
     }
 
+    override fun onConfigurationChanged(newConfig: Configuration?) {
+        super.onConfigurationChanged(newConfig)
+        isConfigurationChanged = true
+    }
+
     override fun setupAdapter(chatMessageDatabaseList: RealmResults<ChatMessage>) {
         val linearLayoutManager = LinearLayoutManager(this)
         linearLayoutManager.stackFromEnd = true
@@ -176,12 +183,16 @@ class ChatActivity: AppCompatActivity(), IChatView {
         rv_chat_feed.adapter = recyclerAdapter
 
         rv_chat_feed.addOnLayoutChangeListener({ _, _, _, _, bottom, _, _, _, oldBottom ->
-            if (bottom < oldBottom) {
-                rv_chat_feed.postDelayed({
-                    var scrollTo = rv_chat_feed.adapter.itemCount - 1
-                    scrollTo = if (scrollTo >= 0) scrollTo else 0
-                    rv_chat_feed.scrollToPosition(scrollTo)
-                }, 10)
+            if (isConfigurationChanged) {
+                isConfigurationChanged = false
+            } else {
+                if (bottom < oldBottom) {
+                    rv_chat_feed.postDelayed({
+                        var scrollTo = rv_chat_feed.adapter.itemCount - 1
+                        scrollTo = if (scrollTo >= 0) scrollTo else 0
+                        rv_chat_feed.scrollToPosition(scrollTo)
+                    }, 10)
+                }
             }
         })
 


### PR DESCRIPTION
Fixes #1164 

Currently, the state of the list is not conserved when the device configuration changes from portrait to landscape. It was due to the logic in `OnLayoutChangeListener`. This pull request solves the issue by taking into consideration the configuration change of the device.