### PR TITLE
Fix #1196: Changes the UI of Skill Listing, Skill details activity

### DIFF
--- a/app/src/main/res/drawable/rounded_button_skilldetails.xml
+++ b/app/src/main/res/drawable/rounded_button_skilldetails.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+        <stroke android:color="@color/md_blue_A400" android:width="2dp" />
+        <solid android:color="@color/susi_message_bg"/>
+
+    <corners android:bottomRightRadius="30dp"
+        android:bottomLeftRadius="30dp"
+        android:topRightRadius="30dp"
+        android:topLeftRadius="30dp"/>
+</shape>

--- a/app/src/main/res/layout/fragment_skill_details.xml
+++ b/app/src/main/res/layout/fragment_skill_details.xml
@@ -17,13 +17,13 @@
 
             <ImageView
                 android:id="@+id/skill_detail_image"
-                android:layout_width="80dp"
-                android:layout_height="80dp"
+                android:layout_width="90dp"
+                android:layout_height="90dp"
                 app:srcCompat="@drawable/ic_susi"
                 android:background="@color/md_white_1000"/>
 
             <LinearLayout
-                android:layout_width="wrap_content"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical"
                 android:layout_marginLeft="16dp"
@@ -34,8 +34,8 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/skill_name"
-                    android:textSize="24sp"
-                    android:layout_marginTop="8dp"
+                    android:textSize="20sp"
+                    android:layout_marginTop="4dp"
                     android:textColor="@color/md_black_1000"
                     android:background="@color/md_white_1000"/>
 
@@ -44,43 +44,47 @@
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:text="@string/author_name"
-                    android:layout_marginTop="8dp"
+                    android:layout_marginTop="4dp"
                     android:background="@color/md_white_1000"/>
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:gravity="right"
+                        android:background="@color/md_white_1000">
+
+                        <Button
+                            android:id="@+id/skill_detail_try_button"
+                            android:layout_width="100dp"
+                            android:layout_height="40dp"
+                            android:text="@string/try_it"
+                            android:textSize="14sp"
+                            android:layout_marginTop="8dp"
+                            android:background="@drawable/rounded_button_skilldetails"
+                            android:textColor="@color/md_blue_A400"
+                            android:layout_marginRight="8dp"
+                            android:layout_marginBottom="8dp"/>
+                        <Button
+                            android:id="@+id/skill_detail_share_button"
+                            android:layout_width="100dp"
+                            android:layout_height="40dp"
+                            android:text="@string/action_share"
+                            android:textSize="14sp"
+                            android:drawableLeft="@drawable/ic_share_white_24dp"
+                            android:drawableStart="@drawable/ic_share_white_24dp"
+                            android:drawableTint="@color/md_blue_A400"
+                            android:padding="10dp"
+                            android:layout_marginTop="8dp"
+                            android:background="@drawable/rounded_button_skilldetails"
+                            android:textColor="@color/md_blue_A400"
+                            android:layout_marginRight="8dp"
+                            android:layout_marginBottom="8dp"/>
+                    </LinearLayout>
+
             </LinearLayout>
 
         </LinearLayout>
 
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:gravity="right"
-            android:background="@color/md_white_1000">
-
-            <Button
-                android:id="@+id/skill_detail_try_button"
-                android:layout_width="100dp"
-                android:layout_height="40dp"
-                android:text="@string/try_it"
-                android:layout_marginTop="8dp"
-                android:background="@color/colorPrimary"
-                android:textColor="@color/md_white_1000"
-                android:layout_marginRight="16dp"
-                android:layout_marginBottom="16dp"/>
-            <Button
-                android:id="@+id/skill_detail_share_button"
-                android:layout_width="100dp"
-                android:layout_height="40dp"
-                android:text="@string/action_share"
-                android:drawableLeft="@drawable/ic_share_white_24dp"
-                android:drawableStart="@drawable/ic_share_white_24dp"
-                android:drawableTint="@color/md_white_1000"
-                android:padding="10dp"
-                android:layout_marginTop="8dp"
-                android:background="@color/colorPrimary"
-                android:textColor="@color/md_white_1000"
-                android:layout_marginRight="16dp"
-                android:layout_marginBottom="16dp"/>
-        </LinearLayout>
 
         <LinearLayout
             android:layout_width="match_parent"
@@ -92,7 +96,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/description"
-                android:textSize="22dp"
+                android:textSize="14sp"
                 android:layout_marginTop="8dp"
                 android:textColor="@color/md_black_1000" />
 
@@ -100,7 +104,7 @@
                 android:id="@+id/skill_detail_description"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textSize="16sp"
+                android:textSize="14sp"
                 android:layout_marginTop="8dp"
                 android:text="@string/description_long"/>
 
@@ -109,7 +113,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/examples"
                 android:layout_marginTop="16dp"
-                android:textSize="22dp"
+                android:textSize="14sp"
                 android:textColor="@color/md_black_1000"/>
 
             <android.support.v7.widget.RecyclerView
@@ -122,7 +126,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:text="@string/rating"
-                android:textSize="22dp"
+                android:textSize="14sp"
                 android:layout_marginTop="16dp"
                 android:textColor="@color/md_black_1000" />
 
@@ -144,6 +148,7 @@
                         android:layout_width="90dp"
                         android:layout_height="wrap_content"
                         android:text="@string/positive_50"
+                        android:textSize="14sp"
                         android:layout_margin="8dp"
                         android:layout_marginTop="4dp"/>
 
@@ -176,6 +181,7 @@
                         android:layout_width="90dp"
                         android:layout_height="wrap_content"
                         android:text="@string/negative_50"
+                        android:textSize="14sp"
                         android:background="@android:color/transparent"
                         android:layout_margin="8dp"
                         android:layout_marginTop="4dp"/>
@@ -197,7 +203,7 @@
                 android:layout_height="wrap_content"
                 android:text="@string/content_type_dynamic"
                 android:layout_marginTop="16dp"
-                android:textSize="18dp"
+                android:textSize="14sp"
                 android:textColor="@color/md_black_1000"/>
 
             <TextView

--- a/app/src/main/res/layout/item_skill.xml
+++ b/app/src/main/res/layout/item_skill.xml
@@ -13,7 +13,8 @@
         android:foreground="?attr/selectableItemBackground"
         android:layout_marginLeft="@dimen/margin_card"
         android:layout_marginTop="@dimen/message_card_margin_small"
-        app:cardBackgroundColor="@color/susi_message_bg">
+        app:cardBackgroundColor="@color/susi_message_bg"
+        app:cardElevation="4dp">
 
         <LinearLayout
             android:id="@+id/preview_layout"
@@ -38,21 +39,41 @@
                     app:srcCompat="@drawable/ic_user"
                     android:padding="@dimen/margin_card" />
 
-                <TextView
-                    android:id="@+id/skill_preview_example"
-                    android:layout_width="0dp"
-                    android:layout_weight="1"
-                    android:layout_height="@dimen/skill_image_size"
-                    android:textSize="@dimen/skill_example"
-                    android:gravity="center"
-                    android:maxLines="3"
-                    android:layout_gravity="center"
-                    android:textAlignment="center"
-                    android:padding="@dimen/standard_content_padding"
-                    android:background="@color/md_white_1000"
-                    android:textColor="@color/md_grey_800"
-                    android:typeface="monospace"
-                    tools:text="@string/sample_website_description" />
+                <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="match_parent"
+                    android:orientation="vertical">
+
+                    <TextView
+                        android:id="@+id/skill_preview_title"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:text="@string/skill_title"
+                        android:textStyle="bold"
+                        android:textColor="@color/colorPrimary"
+                        android:textSize="@dimen/skill_title"
+                        android:ellipsize="end"
+                        android:maxLines="1"
+                        android:background="@color/md_white_1000"
+                        android:paddingLeft="@dimen/cmv_padding"
+                        android:paddingRight="@dimen/cmv_padding"
+                        android:paddingTop="@dimen/cmv_padding"/>
+
+                    <TextView
+                        android:id="@+id/skill_preview_example"
+                        android:layout_width="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_height="@dimen/skill_image_size"
+                        android:textSize="@dimen/skill_example"
+                        android:gravity="left"
+                        android:maxLines="3"
+                        android:layout_gravity="center"
+                        android:textAlignment="center"
+                        android:padding="@dimen/standard_content_padding"
+                        android:background="@color/md_white_1000"
+                        android:textColor="@color/md_grey_800"
+                        tools:text="@string/sample_website_description" />
+                </LinearLayout>
             </LinearLayout>
 
             <LinearLayout
@@ -61,19 +82,6 @@
                 android:orientation="vertical"
                 android:background="@color/default_bg">
 
-                <TextView
-                    android:id="@+id/skill_preview_title"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:text="@string/skill_title"
-                    android:textStyle="bold"
-                    android:textColor="@color/colorPrimary"
-                    android:textSize="@dimen/skill_title"
-                    android:ellipsize="end"
-                    android:maxLines="1"
-                    android:paddingLeft="@dimen/cmv_padding"
-                    android:paddingRight="@dimen/cmv_padding"
-                    android:paddingTop="@dimen/cmv_padding"/>
 
                 <TextView
                     android:id="@+id/skill_preview_description"
@@ -85,7 +93,7 @@
                     android:ellipsize="end"
                     android:minHeight="@dimen/skill_min_height"
                     android:padding="@dimen/cmv_padding"
-                    android:textColor="@color/md_grey_800"
+                    android:textColor="@color/md_grey_500"
                     tools:text="@string/sample_website_description" />
             </LinearLayout>
         </LinearLayout>

--- a/app/src/main/res/layout/item_skill_group.xml
+++ b/app/src/main/res/layout/item_skill_group.xml
@@ -11,9 +11,9 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:text="@string/sample_group"
+        android:textAllCaps="true"
         android:textSize="@dimen/skill_title"
         android:padding="@dimen/margin_card"
-        android:typeface="serif"
         android:textColor="@color/md_black_1000"
         android:textStyle="bold"
         android:layout_marginBottom="@dimen/message_card_margin_medium"/>

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -26,7 +26,7 @@
     <dimen name="map_view_height">180dp</dimen>
     <dimen name="progress_bar_size">50dp</dimen>
     <dimen name="text_size_large">20sp</dimen>
-    <dimen name="skill_image_size">80dp</dimen>
+    <dimen name="skill_image_size">90dp</dimen>
 
     <dimen name="margin_small">5dp</dimen>
     <dimen name="message_card_margin_small">4dp</dimen>
@@ -46,8 +46,8 @@
     <dimen name="padding_img">40dp</dimen>
     <dimen name="toolbar_logo_width">110dp</dimen>
     <dimen name="toolbar_logo_height">22dp</dimen>
-    <dimen name="skill_title">18sp</dimen>
-    <dimen name="skill_description">16sp</dimen>
+    <dimen name="skill_title">12sp</dimen>
+    <dimen name="skill_description">14sp</dimen>
     <dimen name="skill_min_height">60dp</dimen>
     <dimen name="skill_example">14sp</dimen>
 


### PR DESCRIPTION
Fixes #1196 

**Changes**

Implemented Material UI criteria in the Skill details and Skill listing. Also changed the UI a bit following the UI of Google assistant. The UI changes are as follows:
1. Making the Share and Try button in a rounded form with a different layout altogether in the skill details page and also changing the font size according to the Material UI guidelines. 
2. Also changing the format in which a skill in a block in the skill listing page, which even includes rearranging the heading of the skill. 

**Screenshots of the change**

![skilldetailsuichange](https://user-images.githubusercontent.com/30111752/37508077-801c2190-2917-11e8-99bc-38cd7ee20a20.png)

![uichangeforskilllisting](https://user-images.githubusercontent.com/30111752/37508420-f46f85b8-2918-11e8-81e9-457c2b686acc.png)
