### PR TITLE
Fix #1193 - Let the user select his sharing medium

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/adapters/recycleradapters/ChatFeedRecyclerAdapter.java
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/adapters/recycleradapters/ChatFeedRecyclerAdapter.java
@@ -322,7 +322,7 @@ public class ChatFeedRecyclerAdapter extends RealmRecyclerViewAdapter<ChatMessag
         sendIntent.setAction(Intent.ACTION_SEND);
         sendIntent.putExtra(Intent.EXTRA_TEXT, message);
         sendIntent.setType("text/plain");
-        currContext.startActivity(sendIntent);
+        currContext.startActivity(Intent.createChooser(sendIntent, currContext.getString(R.string.share_message) ));
     }
 
     /**

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -145,7 +145,7 @@ class SkillDetailsFragment: Fragment() {
             sendIntent.action = Intent.ACTION_SEND
             sendIntent.putExtra(Intent.EXTRA_TEXT, shareUriBuilder.build().toString())
             sendIntent.type = "text/plain"
-            context.startActivity(sendIntent)
+            context.startActivity(Intent.createChooser(sendIntent, getString(R.string.share_skill)));
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -162,6 +162,8 @@
     <string name="error_skill_listing">Unable to fetch skills. Please try again later.</string>
     <string name="no_skill_author">Skill Author not found</string>
     <string name="reset_password_message">Resetting Password…</string>
+    <string name="share_message">Share Message</string>
+    <string name="share_skill">Share Skill</string>
 
     <!--About Us String-->
     <string name="susi_about"><a href="https://chat.susi.ai/overview">SUSI AI</a> is an intelligent libre software personal assistant. It is capable of chat and voice interaction by using APIs to perform actions such as music playback, making to-do lists, setting alarms, streaming podcasts, playing audiobooks, and providing weather, traffic, and other real time information. Additional functionalities can be added as console services using external APIs. Susi AI is able to answer questions and depending on the context will ask for additional information in order to perform the desired outcome. The core of the assistant is the Susi AI server that holds the "intelligence" and "personality" of SUSI AI.</string>


### PR DESCRIPTION
Fixes #1193 
Changes: Use `Intent.createChooser()` instead of directly launching share

Screenshots of the change: 
![image](https://user-images.githubusercontent.com/22395998/37514288-7ce30be0-292d-11e8-9775-fb5f39369153.png)
