### PR TITLE
Fix #1201: Addition of a delete chat history option in the app

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/helper/Constant.java
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/Constant.java
@@ -21,6 +21,7 @@ public class Constant {
     public static final String HOTWORD_DETECTION = "hotword_detection";
     public static final String SHARE = "share";
     public static final String LOGIN_LOGOUT = "login_logout";
+    public static final String DELETE_CHAT = "delete_chat";
     public static final String RESET_PASSWORD = "reset_password";
     public static final String CHANGE_PASSWORD = "Change Password";
 

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -20,6 +20,7 @@ import android.view.WindowManager
 import android.widget.Toast
 import kotlinx.android.synthetic.main.activity_login.*
 import org.fossasia.susi.ai.R
+import org.fossasia.susi.ai.chat.ChatActivity
 import org.fossasia.susi.ai.data.UtilModel
 import org.fossasia.susi.ai.helper.Constant
 import org.fossasia.susi.ai.login.LoginActivity
@@ -44,6 +45,7 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
     lateinit var hotwordSettings: Preference
     lateinit var share: Preference
     lateinit var loginLogout: Preference
+    lateinit var deleteChat: Preference
     lateinit var resetPassword: Preference
     lateinit var enterSend: Preference
     lateinit var speechAlways: Preference
@@ -74,6 +76,7 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
         hotwordSettings = preferenceManager.findPreference(Constant.HOTWORD_DETECTION)
         share = preferenceManager.findPreference(Constant.SHARE)
         loginLogout = preferenceManager.findPreference(Constant.LOGIN_LOGOUT)
+        deleteChat = preferenceManager.findPreference(Constant.DELETE_CHAT)
         resetPassword = preferenceManager.findPreference(Constant.RESET_PASSWORD)
         enterSend = preferenceManager.findPreference(Constant.ENTER_SEND)
         speechOutput = preferenceManager.findPreference(Constant.SPEECH_OUTPUT)
@@ -136,6 +139,18 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
             } else {
                 settingsPresenter.loginLogout()
             }
+            true
+        }
+
+        deleteChat.setOnPreferenceClickListener {
+            val d= AlertDialog.Builder(activity)
+            d.setMessage("Are you sure ?").setCancelable(false).setPositiveButton("Yes") { _, _ ->
+                settingsPresenter.deleteChat()
+            }.setNegativeButton("No") {dialog, _ -> dialog.cancel()}
+
+            val alert = d.create()
+            alert.setTitle(getString(R.string.delete_chat))
+            alert.show()
             true
         }
 
@@ -266,6 +281,13 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
 
     override fun startLoginActivity() {
         val intent = Intent(activity, LoginActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+        startActivity(intent)
+        activity.finish()
+    }
+
+    override fun startChatActivity() {
+        val intent = Intent(activity, ChatActivity::class.java)
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(intent)
         activity.finish()

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/SettingsPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/SettingsPresenter.kt
@@ -65,6 +65,12 @@ class SettingsPresenter(skillsActivity: SkillsActivity): ISettingsPresenter, ISe
         settingView?.startLoginActivity()
     }
 
+    //This is for deleting the chat history
+    override fun deleteChat() {
+        databaseRepository.deleteAllMessages()
+        settingView?.startChatActivity()
+    }
+
     override fun resetPassword(password: String, newPassword: String, conPassword: String) {
         if (password.isEmpty()) {
             settingView?.invalidCredentials(true, Constant.PASSWORD)

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/contract/ISettingsPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/contract/ISettingsPresenter.kt
@@ -18,6 +18,8 @@ interface ISettingsPresenter {
 
     fun loginLogout()
 
+    fun deleteChat()
+
     fun resetPassword(password: String, newPassword: String, conPassword: String)
 
     fun checkForPassword(password: String, what: String)

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/contract/ISettingsView.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/contract/ISettingsView.kt
@@ -8,6 +8,7 @@ package org.fossasia.susi.ai.skills.settings.contract
 
 interface ISettingsView {
     fun startLoginActivity()
+    fun startChatActivity()
     fun micPermission(): Boolean
     fun hotWordPermission(): Boolean
     fun onSettingResponse(message: String)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -140,6 +140,7 @@
     <string name="email_id_input">Enter your e-mail ID</string>
     <string name="reset">Reset Password</string>
     <string name="reset_pass_activity">Reset Password</string>
+    <string name="clear_chat">Clear chat history</string>
     <string name="wrong_password">Failed. Try again</string>
     <string name="error_password_matching">Passwords do not match</string>
     <string name="pass_change_dialog">Changing your password. Please wait</string>
@@ -156,6 +157,7 @@
     <string name="error_msg_retry">Please Try Again</string>
     <string name="app_share_url" translatable="false">https://play.google.com/store/apps/details?id=%s</string>
     <string name="logout">Log out</string>
+    <string name="delete_chat">Delete chat history</string>
     <string name="skills">Skills</string>
     <string name="skill_title">Skill Title</string>
     <string name="skills_activity">SUSI.AI Skills</string>

--- a/app/src/main/res/xml/pref_settings.xml
+++ b/app/src/main/res/xml/pref_settings.xml
@@ -89,6 +89,10 @@
             android:key="reset_password"/>
 
         <PreferenceScreen
+            android:title="@string/clear_chat"
+            android:key="delete_chat"/>
+
+        <PreferenceScreen
             android:title="Login"
             android:key="login_logout" />
 


### PR DESCRIPTION
Fixes #1201 

Changes: 
I have added a delete chat history option in the settings fragment of the app. This will help user delete his/her chat history on their wish.
