### PR TITLE
Fix #1203 : No Internet Connectivity dialog is shown on pressing skip

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginPresenter.kt
@@ -49,9 +49,14 @@ class LoginPresenter(loginActivity: LoginActivity): ILoginPresenter, ILoginModel
     }
 
     override fun skipLogin() {
-        utilModel.clearToken()
-        utilModel.saveAnonymity(true)
-        loginView?.skipLogin()
+        if(NetworkUtils.isNetworkConnected()) {
+            utilModel.clearToken()
+            utilModel.saveAnonymity(true)
+            loginView?.skipLogin()
+        } else {
+            loginView?.onLoginError(utilModel.getString(R.string.error_internet_connectivity),
+                    utilModel.getString(R.string.no_internet_connection))
+        }
     }
 
     override fun login(email: String, password: String, isSusiServerSelected: Boolean, url: String) {


### PR DESCRIPTION
Fixes #1203
Changes: No Internet Connectivity dialog is shown on pressing skip when there is no Internet connection in the phone instead of opening the chat activity. 

