### PR TITLE
"double circularProgressBarFix"

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
@@ -39,7 +39,7 @@ class SkillListingFragment: Fragment(), ISkillListingView, SwipeRefreshLayout.On
         skillListingPresenter.onAttach(this)
         swipe_refresh_layout.setOnRefreshListener(this)
         setUPAdapter()
-        skillListingPresenter.getGroups()
+        skillListingPresenter.getGroups(swipe_refresh_layout.isRefreshing)
         super.onViewCreated(view, savedInstanceState)
     }
 
@@ -78,7 +78,7 @@ class SkillListingFragment: Fragment(), ISkillListingView, SwipeRefreshLayout.On
 
     override fun onRefresh() {
         setUPAdapter()
-        skillListingPresenter.getGroups()
+        skillListingPresenter.getGroups(swipe_refresh_layout.isRefreshing)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
@@ -28,7 +28,7 @@ class SkillListingPresenter: ISkillListingPresenter,
         this.skillListingView = skillListingView
     }
 
-    override fun getGroups(swipeToRefreshActive:Boolean) {
+    override fun getGroups(swipeToRefreshActive: Boolean) {
         skillListingView?.visibilityProgressBar(true)
         skillListingModel.fetchGroups(this)
     }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
@@ -28,7 +28,7 @@ class SkillListingPresenter: ISkillListingPresenter,
         this.skillListingView = skillListingView
     }
 
-    override fun getGroups() {
+    override fun getGroups(swipeToRefreshActive:Boolean) {
         skillListingView?.visibilityProgressBar(true)
         skillListingModel.fetchGroups(this)
     }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/contract/ISkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/contract/ISkillListingPresenter.kt
@@ -6,6 +6,6 @@ package org.fossasia.susi.ai.skills.skilllisting.contract
  */
 interface ISkillListingPresenter {
     fun onAttach(skillListingView: ISkillListingView)
-    fun getGroups()
+    fun getGroups(swipeToRefreshActive:Boolean)
     fun onDetach()
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/contract/ISkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/contract/ISkillListingPresenter.kt
@@ -6,6 +6,6 @@ package org.fossasia.susi.ai.skills.skilllisting.contract
  */
 interface ISkillListingPresenter {
     fun onAttach(skillListingView: ISkillListingView)
-    fun getGroups(swipeToRefreshActive:Boolean)
+    fun getGroups(swipeToRefreshActive: Boolean)
     fun onDetach()
 }


### PR DESCRIPTION
Fixes #1227 

Changes: added a check before fetchGroups() in skillListingPresenter that we are loading skill data on activity creation or for Refresh

Screenshots for the change: 
<img src="https://image.ibb.co/bvmkvd/Screenshot_2018_05_11_23_33_43.png" width="250" height="400"/>