### PR TITLE
Removed menu from About Us Fragment (Fixed #1242)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -27,7 +27,7 @@ class AboutUsFragment : Fragment() {
         val itemAbout = menu.findItem(R.id.menu_about)
         itemAbout.isVisible = false
         val itemSettings = menu.findItem(R.id.menu_settings)
-        itemSettings.isVisible= true
+        itemSettings.isVisible= false
         var searchoption = menu.findItem(R.id.action_search)
         searchoption.isVisible = false;
         super.onPrepareOptionsMenu(menu)


### PR DESCRIPTION
Fixes #1242 

Changes : Now the About Us Fragment does not contain a menu.