### PR TITLE
Fix lint XML warnings (Fixed #1312)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -34,7 +34,7 @@
             android:configChanges="orientation|screenSize"
             android:label="@string/app_name"
             android:theme="@style/Chat_Theme"
-            android:windowSoftInputMode="adjustResize|stateAlwaysHidden"></activity>
+            android:windowSoftInputMode="adjustResize|stateAlwaysHidden" />
         <activity
             android:name=".skills.SkillsActivity"
             android:configChanges="orientation|screenSize"
@@ -51,7 +51,7 @@
         <activity
             android:name=".login.LoginActivity"
             android:theme="@style/Login_Theme"
-            android:windowSoftInputMode="stateVisible|adjustResize"></activity>
+            android:windowSoftInputMode="stateVisible|adjustResize"/>
         <activity
             android:name=".forgotpassword.ForgotPasswordActivity"
             android:theme="@style/ForgetPass_Theme"

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -105,7 +105,8 @@
                 android:text="@string/activity_login_forgot_pass"
                 android:textSize="16sp"
                 android:textStyle="bold"
-                android:typeface="monospace" />
+                android:typeface="monospace"
+                android:paddingStart="48dp" />
 
             <TextView
                 android:id="@+id/skip"

--- a/app/src/main/res/layout/activity_device.xml
+++ b/app/src/main/res/layout/activity_device.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.constraint.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:context="org.fossasia.susi.ai.device.DeviceActivity">
 
     <TextView

--- a/app/src/main/res/layout/activity_welcome.xml
+++ b/app/src/main/res/layout/activity_welcome.xml
@@ -48,7 +48,8 @@
         android:layout_alignParentLeft="true"
         android:background="@null"
         android:text="@string/skip"
-        android:textColor="@android:color/white" />
+        android:textColor="@android:color/white"
+        android:layout_alignParentStart="true" />
 
     <View
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_skill_details.xml
+++ b/app/src/main/res/layout/fragment_skill_details.xml
@@ -27,7 +27,8 @@
                 android:layout_height="wrap_content"
                 android:layout_marginLeft="16dp"
                 android:background="@color/md_white_1000"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:layout_marginStart="16dp">
 
                 <TextView
                     android:id="@+id/skill_detail_title"
@@ -54,7 +55,7 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="@color/md_white_1000"
-            android:gravity="right">
+            android:gravity="end">
 
             <Button
                 android:id="@+id/skill_detail_try_button"
@@ -65,7 +66,8 @@
                 android:layout_marginTop="8dp"
                 android:background="@color/colorPrimary"
                 android:text="@string/try_it"
-                android:textColor="@color/md_white_1000" />
+                android:textColor="@color/md_white_1000"
+                android:layout_marginEnd="16dp" />
 
             <Button
                 android:id="@+id/skill_detail_share_button"
@@ -80,7 +82,8 @@
                 android:drawableTint="@color/md_white_1000"
                 android:padding="10dp"
                 android:text="@string/action_share"
-                android:textColor="@color/md_white_1000" />
+                android:textColor="@color/md_white_1000"
+                android:layout_marginEnd="16dp" />
         </LinearLayout>
 
         <LinearLayout
@@ -95,7 +98,7 @@
                 android:layout_marginTop="8dp"
                 android:text="@string/description"
                 android:textColor="@color/md_black_1000"
-                android:textSize="22dp" />
+                android:textSize="22sp" />
 
             <TextView
                 android:id="@+id/skill_detail_description"
@@ -111,7 +114,7 @@
                 android:layout_marginTop="16dp"
                 android:text="@string/examples"
                 android:textColor="@color/md_black_1000"
-                android:textSize="22dp" />
+                android:textSize="22sp" />
 
             <android.support.v7.widget.RecyclerView
                 android:id="@+id/skill_detail_examples"
@@ -125,7 +128,7 @@
                 android:layout_marginTop="16dp"
                 android:text="@string/rating"
                 android:textColor="@color/md_black_1000"
-                android:textSize="22dp" />
+                android:textSize="22sp" />
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -164,7 +167,8 @@
                             android:layout_height="wrap_content"
                             android:layout_gravity="center"
                             android:layout_marginRight="8dp"
-                            android:src="@drawable/thumbs_up_solid" />
+                            android:src="@drawable/thumbs_up_solid"
+                            android:layout_marginEnd="8dp" />
 
                     </LinearLayout>
 
@@ -202,7 +206,8 @@
                             android:layout_height="wrap_content"
                             android:layout_gravity="center"
                             android:layout_marginRight="8dp"
-                            android:src="@drawable/thumbs_down_solid" />
+                            android:src="@drawable/thumbs_down_solid"
+                            android:layout_marginEnd="8dp" />
 
                     </LinearLayout>
 
@@ -216,7 +221,7 @@
                 android:layout_marginTop="16dp"
                 android:text="@string/content_type_dynamic"
                 android:textColor="@color/md_black_1000"
-                android:textSize="18dp" />
+                android:textSize="18sp" />
 
             <TextView
                 android:id="@+id/skill_detail_policy"

--- a/app/src/main/res/layout/fragment_sttframe.xml
+++ b/app/src/main/res/layout/fragment_sttframe.xml
@@ -33,8 +33,8 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_above="@id/linearlayout"
-        android:layout_centerInParent="true"
         android:layout_margin="@dimen/activity_vertical_margin"
+        android:textSize="15sp"
         android:textColor="@color/md_black_1000"
-        android:textSize="15dp" />
+        android:layout_centerInParent="true"/>
 </RelativeLayout>

--- a/app/src/main/res/layout/item_example_skill.xml
+++ b/app/src/main/res/layout/item_example_skill.xml
@@ -1,12 +1,14 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/background_layout"
-    android:layout_width="wrap_content"
-    android:layout_height="wrap_content"
-    android:layout_marginBottom="@dimen/message_card_margin_small"
-    android:layout_marginLeft="@dimen/message_card_margin_medium"
-    android:layout_marginTop="@dimen/message_card_margin_small"
-    android:background="@drawable/rounded_layout"
-    android:padding="10dp">
+ <LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:id="@+id/background_layout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="@dimen/message_card_margin_small"
+        android:layout_marginLeft="@dimen/message_card_margin_medium"
+        android:layout_marginTop="@dimen/message_card_margin_small"
+        android:padding="10dp"
+        android:background="@drawable/rounded_layout"
+     android:layout_marginStart="@dimen/message_card_margin_medium">
 
     <TextView
         android:id="@+id/text"

--- a/app/src/main/res/layout/item_skill.xml
+++ b/app/src/main/res/layout/item_skill.xml
@@ -13,7 +13,8 @@
         android:layout_marginLeft="@dimen/margin_card"
         android:layout_marginTop="@dimen/message_card_margin_small"
         android:foreground="?attr/selectableItemBackground"
-        app:cardBackgroundColor="@color/susi_message_bg">
+        app:cardBackgroundColor="@color/susi_message_bg"
+        android:layout_marginStart="@dimen/margin_card">
 
         <LinearLayout
             android:id="@+id/preview_layout"

--- a/app/src/main/res/layout/item_susi_image.xml
+++ b/app/src/main/res/layout/item_susi_image.xml
@@ -12,7 +12,8 @@
         android:layout_marginLeft="@dimen/message_card_margin_medium"
         android:layout_marginTop="@dimen/message_card_margin_small"
         app:cardBackgroundColor="@color/susi_message_bg"
-        app:contentPadding="@dimen/standard_content_padding">
+        app:contentPadding="@dimen/standard_content_padding"
+        android:layout_marginStart="@dimen/message_card_margin_medium">
 
         <ImageView
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_susi_link_preview.xml
+++ b/app/src/main/res/layout/item_susi_link_preview.xml
@@ -13,7 +13,8 @@
         android:layout_marginBottom="@dimen/message_card_margin_small"
         android:layout_marginLeft="@dimen/message_card_margin_medium"
         android:layout_marginTop="@dimen/message_card_margin_small"
-        android:background="@drawable/rounded_layout">
+        android:background="@drawable/rounded_layout"
+        android:layout_marginStart="@dimen/message_card_margin_medium">
 
         <LinearLayout
             android:layout_width="@dimen/message_layout_max_width"
@@ -24,7 +25,7 @@
                 android:id="@+id/chat_bubble_item_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="right"
+                android:layout_gravity="end"
                 android:layout_weight="1"
                 android:paddingBottom="@dimen/padding_chatbubble_small"
                 android:paddingLeft="@dimen/padding_chatbubble_large"
@@ -49,7 +50,8 @@
                     android:layout_height="match_parent"
                     android:layout_gravity="end|right|bottom"
                     android:gravity="center"
-                    android:paddingLeft="8dp">
+                    android:paddingLeft="8dp"
+                    android:paddingStart="8dp">
 
                     <TextView
                         android:id="@+id/timestamp"
@@ -63,15 +65,17 @@
                     <LinearLayout
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:gravity="end"
                         android:layout_marginLeft="@dimen/margin_medium"
-                        android:gravity="right">
+                        android:layout_marginStart="@dimen/margin_medium">
 
                         <ImageView
                             android:id="@+id/thumbs_up"
                             android:layout_width="wrap_content"
                             android:layout_height="wrap_content"
+                            app:srcCompat="@drawable/thumbs_up_outline"
                             android:layout_marginRight="@dimen/message_card_margin_small"
-                            app:srcCompat="@drawable/thumbs_up_outline" />
+                            android:layout_marginEnd="@dimen/message_card_margin_small" />
 
                         <ImageView
                             android:id="@+id/thumbs_down"

--- a/app/src/main/res/layout/item_susi_message.xml
+++ b/app/src/main/res/layout/item_susi_message.xml
@@ -13,9 +13,10 @@
         android:layout_marginBottom="@dimen/message_card_margin_small"
         android:layout_marginLeft="@dimen/message_card_margin_medium"
         android:layout_marginTop="@dimen/message_card_margin_small"
-        android:background="@drawable/rounded_layout"
+        android:padding="@dimen/padding_chatbubble_large"
         android:orientation="vertical"
-        android:padding="@dimen/padding_chatbubble_large">
+        android:background="@drawable/rounded_layout"
+        android:layout_marginStart="@dimen/message_card_margin_medium">
 
         <TextView
             android:id="@+id/text"
@@ -44,18 +45,20 @@
                 android:textColor="@color/timestamp_color"
                 android:textSize="@dimen/timestamp_size" />
 
-            <LinearLayout
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginLeft="@dimen/margin_medium"
-                android:gravity="right">
-
-                <ImageView
-                    android:id="@+id/thumbs_up"
+                <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_marginRight="@dimen/message_card_margin_small"
-                    app:srcCompat="@drawable/thumbs_up_outline" />
+                    android:gravity="end"
+                    android:layout_marginLeft="@dimen/margin_medium"
+                    android:layout_marginStart="@dimen/margin_medium">
+
+                    <ImageView
+                        android:id="@+id/thumbs_up"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        app:srcCompat="@drawable/thumbs_up_outline"
+                        android:layout_marginRight="@dimen/message_card_margin_small"
+                        android:layout_marginEnd="@dimen/message_card_margin_small" />
 
                 <ImageView
                     android:id="@+id/thumbs_down"

--- a/app/src/main/res/layout/item_susi_piechart.xml
+++ b/app/src/main/res/layout/item_susi_piechart.xml
@@ -13,7 +13,8 @@
         android:layout_marginLeft="@dimen/message_card_margin_medium"
         android:layout_marginTop="@dimen/message_card_margin_small"
         app:cardBackgroundColor="@color/susi_message_bg"
-        app:contentPadding="5dp">
+        app:contentPadding="5dp"
+        android:layout_marginStart="@dimen/message_card_margin_medium">
 
         <LinearLayout
             android:layout_width="@dimen/message_layout_max_width"
@@ -24,7 +25,7 @@
                 android:id="@+id/chat_bubble_item_container"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_gravity="right"
+                android:layout_gravity="end"
                 android:layout_weight="1">
 
                 <TextView
@@ -43,7 +44,10 @@
                     android:layout_height="wrap_content"
                     android:layout_gravity="end|right|bottom"
                     android:gravity="center"
-                    android:paddingLeft="@dimen/timestamp_layout_padding">
+                    android:paddingLeft="@dimen/timestamp_layout_padding"
+                    android:paddingStart="@dimen/timestamp_layout_padding"
+                    android:paddingRight="@dimen/timestamp_layout_padding"
+                    android:paddingEnd="@dimen/timestamp_layout_padding">
 
                     <TextView
                         android:id="@+id/timestamp"

--- a/app/src/main/res/layout/item_user_image.xml
+++ b/app/src/main/res/layout/item_user_image.xml
@@ -4,7 +4,7 @@
     android:id="@+id/background_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:gravity="right">
+    android:gravity="end">
 
     <android.support.v7.widget.CardView
         android:layout_width="wrap_content"
@@ -13,7 +13,8 @@
         android:layout_marginRight="@dimen/message_card_margin_medium"
         android:layout_marginTop="@dimen/message_card_margin_small"
         app:cardBackgroundColor="@color/user_message_bg"
-        app:contentPadding="@dimen/standard_content_padding">
+        app:contentPadding="@dimen/standard_content_padding"
+        android:layout_marginEnd="@dimen/message_card_margin_medium">
 
         <ImageView
             android:layout_width="wrap_content"

--- a/app/src/main/res/layout/item_user_link_preview.xml
+++ b/app/src/main/res/layout/item_user_link_preview.xml
@@ -4,8 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:layout_marginTop="@dimen/margin_very_small"
-    android:gravity="right">
+    android:gravity="end"
+    android:layout_marginTop="@dimen/margin_very_small">
 
     <LinearLayout
         android:id="@+id/background_layout"
@@ -13,6 +13,7 @@
         android:layout_height="wrap_content"
         android:layout_marginBottom="@dimen/message_card_margin_small"
         android:layout_marginRight="@dimen/message_card_margin_medium"
+        android:layout_marginEnd="@dimen/message_card_margin_medium"
         android:layout_marginTop="@dimen/message_card_margin_small"
         android:background="@drawable/rounded_layout_grey"
         android:orientation="vertical">
@@ -34,13 +35,15 @@
             android:textColorLink="@color/link_text"
             android:textSize="@dimen/message_text_size" />
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom|end"
-            android:gravity="center"
-            android:paddingLeft="@dimen/timestamp_layout_padding"
-            android:paddingRight="@dimen/padding_chatbubble_large">
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom|end"
+                android:gravity="center"
+                android:paddingLeft="@dimen/timestamp_layout_padding"
+                android:paddingStart="@dimen/timestamp_layout_padding"
+                android:paddingRight="@dimen/padding_chatbubble_large"
+                android:paddingEnd="@dimen/padding_chatbubble_large">
 
             <TextView
                 android:id="@+id/timestamp"
@@ -56,6 +59,7 @@
                 android:layout_width="@dimen/timestamp_size"
                 android:layout_height="@dimen/timestamp_size"
                 android:layout_marginLeft="@dimen/margin_small"
+                android:layout_marginStart="@dimen/margin_small"
                 android:textColor="@color/timestamp_color"
                 app:srcCompat="@drawable/ic_clock" />
 

--- a/app/src/main/res/layout/item_user_message.xml
+++ b/app/src/main/res/layout/item_user_message.xml
@@ -4,7 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_marginTop="@dimen/margin_very_small"
-    android:gravity="right">
+    android:gravity="end">
 
     <LinearLayout
         android:id="@+id/background_layout"
@@ -13,9 +13,10 @@
         android:layout_marginBottom="@dimen/message_card_margin_small"
         android:layout_marginRight="@dimen/message_card_margin_medium"
         android:layout_marginTop="@dimen/message_card_margin_small"
+        android:padding="@dimen/padding_chatbubble_large"
         android:background="@drawable/rounded_layout_grey"
-        android:orientation="vertical"
-        android:padding="@dimen/padding_chatbubble_large">
+        android:layout_marginEnd="@dimen/message_card_margin_medium"
+        android:orientation="vertical">
 
         <TextView
             android:id="@+id/text"
@@ -29,12 +30,13 @@
             android:textColor="@color/message_text_color"
             android:textSize="@dimen/message_text_size" />
 
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom|end"
-            android:gravity="center"
-            android:paddingLeft="@dimen/timestamp_layout_padding">
+            <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="bottom|end"
+                android:gravity="center"
+                android:paddingLeft="@dimen/timestamp_layout_padding"
+                android:paddingStart="@dimen/timestamp_layout_padding">
 
             <TextView
                 android:id="@+id/timestamp"
@@ -45,12 +47,13 @@
                 android:textColor="@color/timestamp_color"
                 android:textSize="@dimen/timestamp_size" />
 
-            <ImageView
-                android:id="@+id/received_tick"
-                android:layout_width="@dimen/timestamp_size"
-                android:layout_height="@dimen/timestamp_size"
-                android:layout_marginLeft="@dimen/margin_small"
-                app:srcCompat="@drawable/ic_clock" />
+                <ImageView
+                    android:id="@+id/received_tick"
+                    android:layout_width="@dimen/timestamp_size"
+                    android:layout_height="@dimen/timestamp_size"
+                    android:layout_marginLeft="@dimen/margin_small"
+                    app:srcCompat="@drawable/ic_clock"
+                    android:layout_marginStart="@dimen/margin_small" />
 
         </LinearLayout>
     </LinearLayout>

--- a/app/src/main/res/layout/item_waiting_dots.xml
+++ b/app/src/main/res/layout/item_waiting_dots.xml
@@ -15,6 +15,9 @@
         android:background="@drawable/rounded_layout"
         android:paddingBottom="@dimen/padding_large"
         android:paddingLeft="@dimen/padding_small"
+        android:layout_marginStart="@dimen/message_card_margin_medium"
+        android:paddingEnd="@dimen/padding_large"
+        android:paddingStart="@dimen/padding_small"
         android:paddingRight="@dimen/padding_large"
         android:paddingTop="@dimen/padding_large">
 

--- a/app/src/main/res/layout/rss_item.xml
+++ b/app/src/main/res/layout/rss_item.xml
@@ -13,7 +13,8 @@
         android:layout_marginLeft="@dimen/message_card_margin_medium"
         android:layout_marginTop="@dimen/message_card_margin_small"
         app:cardBackgroundColor="@color/susi_message_bg"
-        app:contentPadding="@dimen/standard_content_padding">
+        app:contentPadding="@dimen/standard_content_padding"
+        android:layout_marginStart="@dimen/message_card_margin_medium">
 
         <LinearLayout
             android:id="@+id/parent_layout"

--- a/app/src/main/res/layout/search_item.xml
+++ b/app/src/main/res/layout/search_item.xml
@@ -13,7 +13,8 @@
         android:layout_marginLeft="@dimen/message_card_margin_medium"
         android:layout_marginTop="@dimen/message_card_margin_small"
         app:cardBackgroundColor="@color/susi_message_bg"
-        app:contentPadding="@dimen/standard_content_padding">
+        app:contentPadding="@dimen/standard_content_padding"
+        android:layout_marginStart="@dimen/message_card_margin_medium">
 
         <LinearLayout
             android:id="@+id/preview_layout"

--- a/app/src/main/res/layout/search_list.xml
+++ b/app/src/main/res/layout/search_list.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/background_layout"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:layout_marginTop="@dimen/margin_very_small"
-    android:orientation="vertical">
+android:id="@+id/background_layout"
+android:layout_width="match_parent"
+android:layout_height="wrap_content"
+android:orientation="vertical"
+android:layout_marginTop="@dimen/margin_very_small">
 
     <android.support.v7.widget.RecyclerView
         android:id="@+id/recycler_view"

--- a/app/src/main/res/menu/skills_activity_menu.xml
+++ b/app/src/main/res/menu/skills_activity_menu.xml
@@ -4,11 +4,11 @@
     <item
         android:id="@+id/menu_about"
         android:icon="@drawable/ic_about"
-        android:title="About" />
+        android:title="@string/menu_item_about" />
     <item
         android:id="@+id/menu_settings"
         android:icon="@drawable/ic_settings_24dp"
-        android:title="Settings" />
+        android:title="@string/menu_item_settings" />
     <item
         android:id="@+id/action_search"
         android:icon="@drawable/ic_open_search"

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -91,6 +91,6 @@
     <dimen name="mobile_image_size">342dp</dimen>
 
     <dimen name="slide_desc">16dp</dimen>
-    <dimen name="slide_title">30dp</dimen>
+    <dimen name="slide_title">30sp</dimen>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -34,6 +34,9 @@
 
     <string name="id">ID</string>
 
+    <string name="menu_item_about">About</string>
+    <string name="menu_item_settings">Settings</string>
+
     <string name="message_copied">Message copied</string>
 
     <string name="no_internet_connection">Internet Connection Not Available.</string>

--- a/app/src/main/res/xml/pref_settings.xml
+++ b/app/src/main/res/xml/pref_settings.xml
@@ -6,14 +6,14 @@
     <PreferenceCategory android:title="Login email">
         <PreferenceScreen
             android:key="display_email"
-            android:title="test email"></PreferenceScreen>
+            android:title="test email"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/server_settings_title">
         <PreferenceScreen
             android:key="Server_Select"
             android:summary="@string/server_select_summary"
-            android:title="@string/server_pref"></PreferenceScreen>
+            android:title="@string/server_pref"/>
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/settings_title">
@@ -61,7 +61,7 @@
         android:entries="@array/languagentries"
         android:entryValues="@array/languagentry"
         android:key="Lang_Select"
-        android:title="@string/Language"></ListPreference>
+        android:title="@string/Language"/>
 
     <PreferenceCategory android:title="@string/settings_devices">
 


### PR DESCRIPTION
Fixes #1312 

Changes: 
- Removed unused namespace declarations
- Use of 'sp' in place of 'dp' for text sizes
- Use of 'paddingEnd' along with 'paddingRight' etc. to better support right-to-left locale
- Used padding/Margin symmetry wherever possible
- Use of string resource for hardcoded strings
