### PR TITLE
Removed redundant constructs (Fixed #1315)

### DIFF
--- a/app/src/androidTest/java/org/fossasia/susi/ai/forgotpassword/ForgotPasswordActivityTest.kt
+++ b/app/src/androidTest/java/org/fossasia/susi/ai/forgotpassword/ForgotPasswordActivityTest.kt
@@ -1,10 +1,6 @@
 package org.fossasia.susi.ai.forgotpassword
 
-import android.support.design.widget.TextInputEditText
-import android.support.design.widget.TextInputLayout
-import android.support.test.InstrumentationRegistry.getInstrumentation
 import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.action.ViewActions.click
 import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
 import android.support.test.espresso.matcher.ViewMatchers.withId
@@ -14,7 +10,6 @@ import android.support.test.runner.AndroidJUnit4
 import android.util.Log
 import android.view.WindowManager
 import org.fossasia.susi.ai.R
-import org.fossasia.susi.ai.chat.ChatActivityTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/org/fossasia/susi/ai/login/WelcomeActivityTest.kt
+++ b/app/src/androidTest/java/org/fossasia/susi/ai/login/WelcomeActivityTest.kt
@@ -1,4 +1,4 @@
-package org.fossasia.susi.ai.login;
+package org.fossasia.susi.ai.login
 
 import android.support.test.espresso.Espresso.onView
 import android.support.test.espresso.assertion.ViewAssertions.matches
@@ -10,7 +10,6 @@ import android.support.test.runner.AndroidJUnit4
 import android.util.Log
 import android.view.WindowManager
 import org.fossasia.susi.ai.R
-import org.fossasia.susi.ai.chat.ChatActivityTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/org/fossasia/susi/ai/signup/SignUpActivityTest.kt
+++ b/app/src/androidTest/java/org/fossasia/susi/ai/signup/SignUpActivityTest.kt
@@ -1,10 +1,6 @@
 package org.fossasia.susi.ai.signup
 
-import android.support.design.widget.TextInputEditText
-import android.support.design.widget.TextInputLayout
-import android.support.test.InstrumentationRegistry.getInstrumentation
 import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.action.ViewActions.click
 import android.support.test.espresso.action.ViewActions.scrollTo
 import android.support.test.espresso.assertion.ViewAssertions.matches
 import android.support.test.espresso.matcher.ViewMatchers.isDisplayed

--- a/app/src/androidTest/java/org/fossasia/susi/ai/skills/SkillsActivityTest.kt
+++ b/app/src/androidTest/java/org/fossasia/susi/ai/skills/SkillsActivityTest.kt
@@ -1,13 +1,7 @@
 package org.fossasia.susi.ai.skills
 
-import android.support.design.widget.TextInputEditText
-import android.support.design.widget.TextInputLayout
-import android.support.test.InstrumentationRegistry.getInstrumentation
 import android.support.test.espresso.Espresso.onView
-import android.support.test.espresso.action.ViewActions
-import android.support.test.espresso.action.ViewActions.click
 import android.support.test.espresso.assertion.ViewAssertions.matches
-import android.support.test.espresso.matcher.ViewMatchers
 import android.support.test.espresso.matcher.ViewMatchers.isDisplayed
 import android.support.test.espresso.matcher.ViewMatchers.withId
 import android.support.test.filters.LargeTest
@@ -16,7 +10,6 @@ import android.support.test.runner.AndroidJUnit4
 import android.util.Log
 import android.view.WindowManager
 import org.fossasia.susi.ai.R
-import org.fossasia.susi.ai.chat.ChatActivityTest
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
@@ -3,15 +3,19 @@ package org.fossasia.susi.ai.chat
 import ai.kitt.snowboy.MsgEnum
 import ai.kitt.snowboy.audio.AudioDataSaver
 import ai.kitt.snowboy.audio.RecordingThread
-
 import android.Manifest
 import android.app.ProgressDialog
-import android.content.*
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.media.AudioManager
 import android.net.ConnectivityManager
-import android.os.*
+import android.os.Bundle
+import android.os.Handler
+import android.os.Message
 import android.speech.tts.TextToSpeech
 import android.speech.tts.UtteranceProgressListener
 import android.support.design.widget.Snackbar
@@ -26,11 +30,8 @@ import android.view.WindowManager
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
 import android.widget.Toast
-
 import io.realm.RealmResults
-
 import kotlinx.android.synthetic.main.activity_chat.*
-
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.chat.adapters.recycleradapters.ChatFeedRecyclerAdapter
 import org.fossasia.susi.ai.chat.contract.IChatPresenter
@@ -38,7 +39,6 @@ import org.fossasia.susi.ai.chat.contract.IChatView
 import org.fossasia.susi.ai.data.model.ChatMessage
 import org.fossasia.susi.ai.helper.Constant
 import org.fossasia.susi.ai.skills.SkillsActivity
-
 import java.util.*
 
 /**
@@ -405,10 +405,6 @@ class ChatActivity : AppCompatActivity(), IChatView {
 
     override fun hideRetrieveOldMessageProgress() {
         progressDialog.dismiss()
-    }
-
-    override fun onBackPressed() {
-        super.onBackPressed();
     }
 
     override fun finishActivity() {

--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatPresenter.kt
@@ -371,13 +371,12 @@ class ChatPresenter(chatActivity: ChatActivity) : IChatPresenter, IChatModel.OnR
 
             for (i in 0..actionSize - 1) {
                 val delay = response.body().answers[0].actions[i].delay
-                val actionNo = i
                 val handler = Handler()
                 handler.postDelayed({
                     val psh = ParseSusiResponseHelper()
-                    psh.parseSusiResponse(susiResponse, actionNo, utilModel.getString(R.string.error_occurred_try_again))
+                    psh.parseSusiResponse(susiResponse, i, utilModel.getString(R.string.error_occurred_try_again))
 
-                    var setMessage = psh.answer;
+                    var setMessage = psh.answer
                     if (psh.actionType == Constant.ANSWER && (PrefManager.checkSpeechOutputPref() && check || PrefManager.checkSpeechAlwaysPref())) {
                         setMessage = psh.answer
 

--- a/app/src/main/java/org/fossasia/susi/ai/chat/ParseSusiResponseHelper.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ParseSusiResponseHelper.kt
@@ -68,7 +68,7 @@ class ParseSusiResponseHelper {
             Constant.TABLE -> try {
                 datumList = susiResponse.answers[0].data
             } catch (e: Exception) {
-                datumList = null;
+                datumList = null
             }
 
             Constant.WEBSEARCH -> try {

--- a/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
@@ -16,8 +16,6 @@ import android.widget.Toast
 import kotlinx.android.synthetic.main.activity_chat.*
 import kotlinx.android.synthetic.main.fragment_sttframe.*
 import org.fossasia.susi.ai.R
-import org.fossasia.susi.ai.R.id.speechprogress
-import org.fossasia.susi.ai.R.id.txtchat
 import org.fossasia.susi.ai.chat.contract.IChatPresenter
 
 /**

--- a/app/src/main/java/org/fossasia/susi/ai/data/ChatModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/ChatModel.kt
@@ -11,7 +11,6 @@ import org.fossasia.susi.ai.rest.services.LocationService
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
-import java.util.*
 
 /**
  * The Model of Chat Activity.

--- a/app/src/main/java/org/fossasia/susi/ai/data/SkillListingModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/SkillListingModel.kt
@@ -4,7 +4,6 @@ import org.fossasia.susi.ai.data.contract.ISkillListingModel
 import org.fossasia.susi.ai.rest.ClientBuilder
 import org.fossasia.susi.ai.rest.responses.susi.ListGroupsResponse
 import org.fossasia.susi.ai.rest.responses.susi.ListSkillsResponse
-import org.fossasia.susi.ai.rest.responses.susi.LoginResponse
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response

--- a/app/src/main/java/org/fossasia/susi/ai/data/UtilModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/UtilModel.kt
@@ -65,7 +65,7 @@ class UtilModel(val context: Context) : IUtilModel {
     }
 
     override fun getBooleanPref(prefName: String, defaultValue: Boolean): Boolean {
-        return PrefManager.getBoolean(prefName, defaultValue);
+        return PrefManager.getBoolean(prefName, defaultValue)
     }
 
     override fun putBooleanPref(prefName: String, value: Boolean) {

--- a/app/src/main/java/org/fossasia/susi/ai/data/db/DatabaseRepository.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/db/DatabaseRepository.kt
@@ -95,10 +95,9 @@ class DatabaseRepository : IDatabaseRepository {
             }
         }, {
             if (!mine) {
-                val prId = prevId
                 realm.executeTransactionAsync { bgRealm ->
                     try {
-                        val previouschatMessage = bgRealm.where(ChatMessage::class.java).equalTo("id", prId).findFirst()
+                        val previouschatMessage = bgRealm.where(ChatMessage::class.java).equalTo("id", prevId).findFirst()
                         if (previouschatMessage != null && previouschatMessage.isMine) {
                             previouschatMessage.isDelivered = true
                             previouschatMessage.date = date
@@ -109,11 +108,11 @@ class DatabaseRepository : IDatabaseRepository {
                     }
 
                     try {
-                        val previousChatMessage = bgRealm.where(ChatMessage::class.java).equalTo("id", prId - 1).findFirst()
+                        val previousChatMessage = bgRealm.where(ChatMessage::class.java).equalTo("id", prevId - 1).findFirst()
                         if (previousChatMessage != null && previousChatMessage.isDate) {
                             previousChatMessage.date = date
                             previousChatMessage.timeStamp = timeStamp
-                            val previousChatMessage2 = bgRealm.where(ChatMessage::class.java).equalTo("id", prId - 2).findFirst()
+                            val previousChatMessage2 = bgRealm.where(ChatMessage::class.java).equalTo("id", prevId - 2).findFirst()
                             if (previousChatMessage2 != null && previousChatMessage2.date == previousChatMessage.date) {
                                 previousChatMessage.deleteFromRealm()
                             }

--- a/app/src/main/java/org/fossasia/susi/ai/device/DeviceActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/device/DeviceActivity.kt
@@ -1,16 +1,15 @@
 package org.fossasia.susi.ai.device
 
-import android.support.v7.app.AppCompatActivity
+import android.content.ComponentName
+import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AlertDialog
+import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
 import android.view.View
-import org.fossasia.susi.ai.BuildConfig
+import android.widget.Toast
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.device.contract.IDeviceView
-import android.content.Intent
-import android.content.ComponentName
-import android.widget.Toast
 
 
 class DeviceActivity : AppCompatActivity(), IDeviceView {

--- a/app/src/main/java/org/fossasia/susi/ai/helper/ConstraintsHelper.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/ConstraintsHelper.kt
@@ -3,7 +3,6 @@ package org.fossasia.susi.ai.helper
 import android.content.Context
 import android.graphics.Rect
 import android.support.v7.widget.RecyclerView
-import android.util.Log
 import android.util.TypedValue
 import android.view.View
 

--- a/app/src/main/java/org/fossasia/susi/ai/helper/MediaUtil.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/MediaUtil.kt
@@ -1,16 +1,14 @@
 package org.fossasia.susi.ai.helper
 
-import java.io.File
-import java.io.IOException
-
 import android.Manifest
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
-import android.content.pm.ResolveInfo
 import android.media.MediaRecorder
 import android.speech.RecognizerIntent
 import android.support.v4.app.ActivityCompat
+import java.io.File
+import java.io.IOException
 
 /**
  * <h1>Helper class to check if STT and TTS is possible for phone.</h1>

--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
@@ -1,12 +1,9 @@
 package org.fossasia.susi.ai.login
 
 import android.app.ProgressDialog
-import android.content.Context
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
-import android.os.Handler
-import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
 import android.view.View
 import android.view.inputmethod.EditorInfo
@@ -14,7 +11,6 @@ import android.widget.ArrayAdapter
 import android.widget.Toast
 import kotlinx.android.synthetic.main.activity_login.*
 import org.fossasia.susi.ai.R
-import org.fossasia.susi.ai.signup.SignUpActivity
 import org.fossasia.susi.ai.chat.ChatActivity
 import org.fossasia.susi.ai.forgotpassword.ForgotPasswordActivity
 import org.fossasia.susi.ai.helper.AlertboxHelper
@@ -22,6 +18,7 @@ import org.fossasia.susi.ai.helper.Constant
 import org.fossasia.susi.ai.helper.PrefManager
 import org.fossasia.susi.ai.login.contract.ILoginPresenter
 import org.fossasia.susi.ai.login.contract.ILoginView
+import org.fossasia.susi.ai.signup.SignUpActivity
 
 /**
  * <h1>The Login activity.</h1>

--- a/app/src/main/java/org/fossasia/susi/ai/signup/SignUpActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/signup/SignUpActivity.kt
@@ -5,7 +5,6 @@ import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
-import android.support.v7.app.AlertDialog
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
 import android.view.View

--- a/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
@@ -1,31 +1,24 @@
 package org.fossasia.susi.ai.skills
 
 import android.content.Context
+import android.content.Intent
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
-import org.fossasia.susi.ai.R
-import android.content.Intent
-import android.util.Log
+import android.view.KeyEvent
 import android.view.Menu
 import android.view.MenuItem
-import org.fossasia.susi.ai.chat.ChatActivity
-import org.fossasia.susi.ai.skills.aboutus.AboutUsFragment
-import org.fossasia.susi.ai.skills.settings.ChatSettingsFragment
-import org.fossasia.susi.ai.skills.skilldetails.SkillDetailsFragment
-import org.fossasia.susi.ai.skills.skilllisting.SkillListingFragment
-
-import android.view.inputmethod.InputMethodManager.SHOW_IMPLICIT
-import android.content.Context.INPUT_METHOD_SERVICE
-import android.support.v7.widget.RecyclerView
-import android.view.KeyEvent
 import android.view.inputmethod.EditorInfo
 import android.view.inputmethod.InputMethodManager
-import android.widget.TextView
 import android.widget.EditText
+import android.widget.TextView
 import android.widget.Toast
 import kotlinx.android.synthetic.main.fragment_skill_listing.*
-import org.fossasia.susi.ai.R.id.skillGroups
+import org.fossasia.susi.ai.R
+import org.fossasia.susi.ai.chat.ChatActivity
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
+import org.fossasia.susi.ai.skills.aboutus.AboutUsFragment
+import org.fossasia.susi.ai.skills.settings.ChatSettingsFragment
+import org.fossasia.susi.ai.skills.skilllisting.SkillListingFragment
 
 
 /**
@@ -106,10 +99,10 @@ class SkillsActivity : AppCompatActivity() {
             }
 
             R.id.action_search -> {
-                handleMenuSearch();
+                handleMenuSearch()
             }
         }
-        return super.onOptionsItemSelected(item);
+        return super.onOptionsItemSelected(item)
     }
 
     protected fun handleMenuSearch() {
@@ -189,7 +182,7 @@ class SkillsActivity : AppCompatActivity() {
     }
 
     override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
-        mSearchAction = menu?.findItem(R.id.action_search);
+        mSearchAction = menu?.findItem(R.id.action_search)
         return super.onPrepareOptionsMenu(menu)
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -31,7 +31,7 @@ class AboutUsFragment : Fragment() {
         val itemSettings = menu.findItem(R.id.menu_settings)
         itemSettings.isVisible = false
         var searchoption = menu.findItem(R.id.action_search)
-        searchoption.isVisible = false;
+        searchoption.isVisible = false
         super.onPrepareOptionsMenu(menu)
     }
 

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -5,12 +5,9 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
-import android.support.annotation.NonNull
-import android.support.annotation.Nullable
 import android.support.design.widget.TextInputEditText
 import android.support.design.widget.TextInputLayout
 import android.support.v4.app.ActivityCompat
-import android.support.v4.content.ContextCompat.startActivity
 import android.support.v7.app.AlertDialog
 import android.support.v7.preference.ListPreference
 import android.support.v7.preference.Preference
@@ -20,19 +17,16 @@ import android.view.Menu
 import android.view.View
 import android.view.WindowManager
 import android.widget.Toast
-import kotlinx.android.synthetic.main.activity_login.*
+import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.data.UtilModel
 import org.fossasia.susi.ai.device.DeviceActivity
 import org.fossasia.susi.ai.helper.Constant
-import org.fossasia.susi.ai.login.LoginActivity
 import org.fossasia.susi.ai.helper.PrefManager
-import org.fossasia.susi.ai.signup.SignUpActivity
+import org.fossasia.susi.ai.login.LoginActivity
+import org.fossasia.susi.ai.skills.SkillsActivity
 import org.fossasia.susi.ai.skills.settings.contract.ISettingsPresenter
 import org.fossasia.susi.ai.skills.settings.contract.ISettingsView
-import org.fossasia.susi.ai.skills.SkillsActivity
-import com.takisoft.fix.support.v7.preference.PreferenceFragmentCompat
-import org.fossasia.susi.ai.rest.responses.susi.Skills
 
 /**
  * The Fragment for Settings Activity
@@ -91,7 +85,7 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
         setupDevice = preferenceManager.findPreference(Constant.DEVICE_SETUP)
 
         // Display login email
-        var utilModel: UtilModel = UtilModel(activity as SkillsActivity)
+        var utilModel = UtilModel(activity as SkillsActivity)
         if (utilModel.isLoggedIn() == false)
             displayEmail.title = "Not logged in"
         else
@@ -208,7 +202,7 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
         val itemAbout = menu.findItem(R.id.menu_about)
         itemAbout.isVisible = false
         var searchoption = menu.findItem(R.id.action_search)
-        searchoption.isVisible = false;
+        searchoption.isVisible = false
         super.onPrepareOptionsMenu(menu)
     }
 

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -1,9 +1,11 @@
 package org.fossasia.susi.ai.skills.skilldetails
 
-import android.support.v4.app.Fragment
 import android.content.Intent
+import android.net.Uri
 import android.os.Build
 import android.os.Bundle
+import android.support.annotation.NonNull
+import android.support.v4.app.Fragment
 import android.support.v7.widget.LinearLayoutManager
 import android.text.Html
 import android.text.method.LinkMovementMethod
@@ -18,9 +20,6 @@ import org.fossasia.susi.ai.rest.responses.susi.SkillData
 import org.fossasia.susi.ai.skills.SkillsActivity
 import org.fossasia.susi.ai.skills.skilldetails.adapters.recycleradapters.SkillExamplesAdapter
 import java.io.Serializable
-import android.net.Uri
-import android.support.annotation.NonNull
-import org.fossasia.susi.ai.R.id.*
 
 /**
  *
@@ -148,7 +147,7 @@ class SkillDetailsFragment : Fragment() {
             sendIntent.action = Intent.ACTION_SEND
             sendIntent.putExtra(Intent.EXTRA_TEXT, shareUriBuilder.build().toString())
             sendIntent.type = "text/plain"
-            context?.startActivity(Intent.createChooser(sendIntent, getString(R.string.share_skill)));
+            context?.startActivity(Intent.createChooser(sendIntent, getString(R.string.share_skill)))
         }
     }
 
@@ -266,7 +265,4 @@ class SkillDetailsFragment : Fragment() {
         }
     }
 
-    override fun onDestroyView() {
-        super.onDestroyView()
-    }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
@@ -1,8 +1,8 @@
 package org.fossasia.susi.ai.skills.skilllisting
 
-import android.support.v4.app.Fragment
 import android.os.Bundle
 import android.support.annotation.NonNull
+import android.support.v4.app.Fragment
 import android.support.v4.widget.SwipeRefreshLayout
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.SnapHelper
@@ -63,7 +63,7 @@ class SkillListingFragment : Fragment(), ISkillListingView, SwipeRefreshLayout.O
     override fun displayError() {
         if (activity != null) {
             swipe_refresh_layout.isRefreshing = false
-            skillGroups.visibility = GONE;
+            skillGroups.visibility = GONE
             error_skill_fetch.visibility = View.VISIBLE
         }
     }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillGroupAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillGroupAdapter.kt
@@ -5,13 +5,12 @@ import android.support.annotation.NonNull
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.RecyclerView
 import android.support.v7.widget.SnapHelper
-import android.view.ViewGroup
-import org.fossasia.susi.ai.rest.responses.susi.SkillData
-import org.fossasia.susi.ai.skills.skilllisting.adapters.viewholders.GroupViewHolder
 import android.view.LayoutInflater
-import kotlinx.android.synthetic.main.fragment_skill_listing.*
+import android.view.ViewGroup
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.helper.StartSnapHelper
+import org.fossasia.susi.ai.rest.responses.susi.SkillData
+import org.fossasia.susi.ai.skills.skilllisting.adapters.viewholders.GroupViewHolder
 
 /**
  *

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
@@ -10,7 +10,6 @@ import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
 import org.fossasia.susi.ai.skills.SkillsActivity
 import org.fossasia.susi.ai.skills.skilldetails.SkillDetailsFragment
-import org.fossasia.susi.ai.skills.skilllisting.SkillListingFragment
 import org.fossasia.susi.ai.skills.skilllisting.adapters.viewholders.SkillViewHolder
 
 /**


### PR DESCRIPTION
Fixes #1315 

Changes: Removed redundant code constructs :
- Explicitly given type which is redundant
- Redundant overrides
- Redundant semicolons
- Unnecessary local variables
- Unused imports