### PR TITLE
Hide rating bar when the user is not logged in (Fixed #1362)

### DIFF
--- a/app/src/main/res/layout/fragment_skill_details.xml
+++ b/app/src/main/res/layout/fragment_skill_details.xml
@@ -138,7 +138,8 @@
                 android:gravity="center_horizontal"
                 android:text="@string/rate_skill"
                 android:textSize="@dimen/message_text_size"
-                android:textStyle="italic" />
+                android:textStyle="italic"
+                android:visibility="gone" />
 
             <!-- Add a five star rating bar -->
             <RatingBar
@@ -148,7 +149,8 @@
                 android:layout_gravity="center_horizontal"
                 android:numStars="5"
                 android:rating="5"
-                android:stepSize="1" />
+                android:stepSize="1"
+                android:visibility="gone" />
 
             <!-- Display what a particular rating implies -->
             <TextView
@@ -159,7 +161,8 @@
                 android:paddingBottom="@dimen/padding_small"
                 android:text="@string/rate_awesome"
                 android:textSize="@dimen/message_text_size"
-                android:textStyle="bold" />
+                android:textStyle="bold"
+                android:visibility="gone" />
 
             <LinearLayout
                 android:id="@+id/skill_rating_view"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -335,8 +335,6 @@
     <string name="rate_good">Good</string>
     <string name="rate_improvement">Need some improvement</string>
     <string name="rate_hate">Hated it</string>
-    <string name="average_rating_for_unrated_skill">0.0</string>
-    <string name="total_rating_for_unrated_skill">0</string>
-
+    <string name="skill_unrated_for_anonymous_user">Skill not rated yet. Please login to rate the skill.</string>
 
 </resources>


### PR DESCRIPTION
Fixes #1362 

Changes: Hid the rating bar when the user is not logged in.

**Screenshot : When user is logged in**

![screenshot_1528392083](https://user-images.githubusercontent.com/30979369/41116034-d5f71626-6aa6-11e8-94e3-6fb7978b3dc9.png)


![screenshot_1528392095](https://user-images.githubusercontent.com/30979369/41116050-e1f2d884-6aa6-11e8-836a-072bca516a8e.png)


**Screenshot : When user is not logged in**

![screenshot_1528392649](https://user-images.githubusercontent.com/30979369/41116077-f064e29a-6aa6-11e8-8738-cf73c12eda0e.png)

![screenshot_1528392138](https://user-images.githubusercontent.com/30979369/41116093-f93e97da-6aa6-11e8-8c6b-0fbe7957abe2.png)
