### PR TITLE
Send device_type=Android in the chat.json query

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatPresenter.kt
@@ -41,6 +41,7 @@ class ChatPresenter(chatActivity: ChatActivity) : IChatPresenter, IChatModel.OnR
     private var micCheck = false
     var latitude: Double = 0.0
     var longitude: Double = 0.0
+    var deviceType: String = "Android"
     private var source = Constant.IP
     private var isDetectionOn = false
     var check = false
@@ -315,7 +316,7 @@ class ChatPresenter(chatActivity: ChatActivity) : IChatPresenter, IChatModel.OnR
                 val query = nonDeliveredMessages.first.first
                 val language = if (PrefManager.getString(Constant.LANGUAGE, Constant.DEFAULT) == Constant.DEFAULT) Locale.getDefault().language else PrefManager.getString(Constant.LANGUAGE, Constant.DEFAULT)
 
-                chatModel.getSusiMessage(timezoneOffset, longitude, latitude, source, language, query, this)
+                chatModel.getSusiMessage(timezoneOffset, longitude, latitude, source, language, deviceType, query, this)
 
             } else run {
                 queueExecuting.set(false)
@@ -442,7 +443,7 @@ class ChatPresenter(chatActivity: ChatActivity) : IChatPresenter, IChatModel.OnR
         val now = Date()
         val timezoneOffset = -1 * (tz.getOffset(now.time) / 60000)
         val language = if (PrefManager.getString(Constant.LANGUAGE, Constant.DEFAULT).equals(Constant.DEFAULT)) Locale.getDefault().language else PrefManager.getString(Constant.LANGUAGE, Constant.DEFAULT)
-        chatModel.getTableSusiMessage(timezoneOffset, longitude, latitude, source, language, query, this)
+        chatModel.getTableSusiMessage(timezoneOffset, longitude, latitude, source, language, deviceType, query, this)
     }
 
     override fun onDatabaseUpdateSuccess() {

--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatPresenter.kt
@@ -41,7 +41,7 @@ class ChatPresenter(chatActivity: ChatActivity) : IChatPresenter, IChatModel.OnR
     private var micCheck = false
     var latitude: Double = 0.0
     var longitude: Double = 0.0
-    var deviceType: String = "Android"
+    private val deviceType = "Android"
     private var source = Constant.IP
     private var isDetectionOn = false
     var check = false

--- a/app/src/main/java/org/fossasia/susi/ai/data/ChatModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/ChatModel.kt
@@ -52,9 +52,9 @@ class ChatModel : IChatModel {
     }
 
     override fun getSusiMessage(timezoneOffset: Int, longitude: Double, latitude: Double, source: String,
-                                language: String, query: String, listener: IChatModel.OnMessageFromSusiReceivedListener) {
+                                language: String, deviceType: String, query: String, listener: IChatModel.OnMessageFromSusiReceivedListener) {
 
-        clientBuilder.susiApi.getSusiResponse(timezoneOffset, longitude, latitude, source, language, query).enqueue(
+        clientBuilder.susiApi.getSusiResponse(timezoneOffset, longitude, latitude, source, language, deviceType, query).enqueue(
                 object : Callback<SusiResponse> {
                     override fun onResponse(call: Call<SusiResponse>, response: Response<SusiResponse>?) {
                         listener.onSusiMessageReceivedSuccess(response)
@@ -72,9 +72,9 @@ class ChatModel : IChatModel {
     }
 
     override fun getTableSusiMessage(timezoneOffset: Int, longitude: Double, latitude: Double, source: String,
-                                     language: String, query: String, listener: IChatModel.OnMessageFromSusiReceivedListener) {
+                                     language: String, deviceType: String, query: String, listener: IChatModel.OnMessageFromSusiReceivedListener) {
 
-        clientBuilder.susiApi.getTableSusiResponse(timezoneOffset, longitude, latitude, source, language, query).enqueue(
+        clientBuilder.susiApi.getTableSusiResponse(timezoneOffset, longitude, latitude, source, language, deviceType, query).enqueue(
                 object : Callback<TableSusiResponse> {
                     override fun onResponse(call: Call<TableSusiResponse>, response: Response<TableSusiResponse>?) {
                         listener.onTableMessageReceivedSuccess(response)

--- a/app/src/main/java/org/fossasia/susi/ai/data/contract/IChatModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/contract/IChatModel.kt
@@ -29,10 +29,10 @@ interface IChatModel {
     }
 
     fun getTableSusiMessage(timezoneOffset: Int, longitude: Double, latitude: Double, source: String,
-                        language: String, query: String, listener: IChatModel.OnMessageFromSusiReceivedListener)
+                        language: String, deviceType: String, query: String, listener: IChatModel.OnMessageFromSusiReceivedListener)
 
     fun getSusiMessage(timezoneOffset: Int, longitude: Double, latitude: Double, source: String,
-                       language: String, query: String, listener: OnMessageFromSusiReceivedListener)
+                       language: String, deviceType: String, query: String, listener: OnMessageFromSusiReceivedListener)
 
     fun retrieveOldMessages(listener: OnRetrievingMessagesFinishedListener)
     fun getLocationFromIP(listener: OnLocationFromIPReceivedListener)

--- a/app/src/main/java/org/fossasia/susi/ai/rest/services/SusiService.java
+++ b/app/src/main/java/org/fossasia/susi/ai/rest/services/SusiService.java
@@ -51,6 +51,7 @@ public interface SusiService {
                                        @Query("latitude") double latitude,
                                        @Query("geosource") String geosource,
                                        @Query("language") String language,
+                                       @Query("device_type") String deviceType,
                                        @Query("q") String query);
 
     /**
@@ -70,6 +71,7 @@ public interface SusiService {
                                                  @Query("latitude") double latitude,
                                                  @Query("geosource") String geosource,
                                                  @Query("language") String language,
+                                                 @Query("device_type") String deviceType,
                                                  @Query("q") String query);
 
     /**

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.3'
+        classpath 'com.android.tools.build:gradle:3.1.2'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath "io.realm:realm-gradle-plugin:3.7.2"

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.1.2'
+        classpath 'com.android.tools.build:gradle:3.1.3'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.4.1'
         classpath "io.realm:realm-gradle-plugin:3.7.2"


### PR DESCRIPTION
Fixes #1406 
Send device type in chat.json API 

Changes: 
Modified getSusiMessage() and getTableSusiMessage() functions to send device_type="Android" in the query 

Screenshots for the change: 
NA