### PR TITLE
Hide skill rating text when the rating bar has zero rating (Fixed #1398)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -244,7 +244,6 @@ class SkillDetailsFragment : Fragment() {
 
         tvFiveStarSkillRatingBar.visibility = View.VISIBLE
         fiveStarSkillRatingBar.visibility = View.VISIBLE
-        fiveStarSkillRatingScaleTextView.visibility = View.VISIBLE
 
         //Set up the OnRatingCarChange listener to change the rating scale text view contents accordingly
         fiveStarSkillRatingBar.setOnRatingBarChangeListener({ ratingBar, v, b ->

--- a/app/src/main/res/layout/fragment_skill_details.xml
+++ b/app/src/main/res/layout/fragment_skill_details.xml
@@ -160,7 +160,6 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:paddingBottom="@dimen/padding_small"
-                android:text="@string/rate_awesome"
                 android:textSize="@dimen/message_text_size"
                 android:textStyle="bold"
                 android:visibility="gone" />


### PR DESCRIPTION
Fixes #1398 

Changes: Hide the skill rating text when rating bar shows zero rating.

Screenshots for the change: 

Earlier : 
![screenshot_1528886530](https://user-images.githubusercontent.com/30979369/41378512-e20f37ec-6f7c-11e8-9f7e-5eb8ef22691c.png)


Now :
![screenshot_1528924050](https://user-images.githubusercontent.com/30979369/41378578-169ecd06-6f7d-11e8-9d73-bae0e48563fa.png)
