### PR TITLE
Show skills in the language chosen by the user (Fixed #1142)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/data/SkillListingModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/SkillListingModel.kt
@@ -36,9 +36,9 @@ class SkillListingModel : ISkillListingModel {
         })
     }
 
-    override fun fetchSkills(group: String, listener: ISkillListingModel.OnFetchSkillsFinishedListener) {
+    override fun fetchSkills(group: String, language: String, listener: ISkillListingModel.OnFetchSkillsFinishedListener) {
 
-        authResponseCallSkills = clientBuilder.susiApi.fetchListSkills(group, "true", "descending", "rating")
+        authResponseCallSkills = clientBuilder.susiApi.fetchListSkills(group, language, "true", "descending", "rating")
 
         authResponseCallSkills.enqueue(object : Callback<ListSkillsResponse> {
             override fun onResponse(call: Call<ListSkillsResponse>, response: Response<ListSkillsResponse>) {

--- a/app/src/main/java/org/fossasia/susi/ai/data/contract/ISkillListingModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/contract/ISkillListingModel.kt
@@ -21,7 +21,7 @@ interface ISkillListingModel {
 
     fun fetchGroups(listener: OnFetchGroupsFinishedListener)
 
-    fun fetchSkills(group: String, listener: OnFetchSkillsFinishedListener)
+    fun fetchSkills(group: String, language: String, listener: OnFetchSkillsFinishedListener)
 
     fun cancelFetch()
 }

--- a/app/src/main/java/org/fossasia/susi/ai/helper/Constant.java
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/Constant.java
@@ -37,7 +37,7 @@ public class Constant {
     public static final String SELECT_SERVER = "Server_Select";
     public static final String LANG_SELECT = "Lang_Select";
     public static final String LANGUAGE = "prefLanguage";
-    public static final String DEFAULT = "default";
+    public static final String DEFAULT = "en";
     public static final String RATE = "rate";
     public static final String DEVICE = "device";
     public static final String DEVICE_SETUP = "setup";

--- a/app/src/main/java/org/fossasia/susi/ai/rest/services/SusiService.java
+++ b/app/src/main/java/org/fossasia/susi/ai/rest/services/SusiService.java
@@ -179,6 +179,7 @@ public interface SusiService {
 
     @GET("/cms/getSkillList.json")
     Call<ListSkillsResponse> fetchListSkills(@Query("group") String groups,
+                                             @Query("language") String language,
                                              @Query("applyFilter") String applyFilter,
                                              @Query("filter_name") String filterName,
                                              @Query("filter_type") String filterType);

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -1,6 +1,7 @@
 package org.fossasia.susi.ai.skills.settings
 
 import android.Manifest
+import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -107,6 +108,9 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
             if (!settingsPresenter.getAnonymity()) {
                 settingsPresenter.sendSetting(Constant.LANGUAGE, newValue.toString(), 1)
             }
+            val intent = Intent(context, SkillsActivity::class.java)
+            startActivity(intent)
+            (context as Activity).finish()
             true
         }
         rate.setOnPreferenceClickListener {

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
@@ -2,6 +2,8 @@ package org.fossasia.susi.ai.skills.skilllisting
 
 import org.fossasia.susi.ai.data.SkillListingModel
 import org.fossasia.susi.ai.data.contract.ISkillListingModel
+import org.fossasia.susi.ai.helper.Constant
+import org.fossasia.susi.ai.helper.PrefManager
 import org.fossasia.susi.ai.rest.responses.susi.ListGroupsResponse
 import org.fossasia.susi.ai.rest.responses.susi.ListSkillsResponse
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
@@ -37,7 +39,7 @@ class SkillListingPresenter : ISkillListingPresenter,
         if (response.isSuccessful && response.body() != null) {
             groupsCount = response.body().groups.size
             groups = response.body().groups
-            skillListingModel.fetchSkills(groups[0], this)
+            skillListingModel.fetchSkills(groups[0], PrefManager.getString(Constant.LANGUAGE, Constant.DEFAULT), this)
         } else {
             skillListingView?.visibilityProgressBar(false)
             skillListingView?.displayError()
@@ -58,7 +60,7 @@ class SkillListingPresenter : ISkillListingPresenter,
                 skillListingView?.updateAdapter(skills)
             }
             if (count != groupsCount) {
-                skillListingModel.fetchSkills(groups[count], this)
+                skillListingModel.fetchSkills(groups[count], PrefManager.getString(Constant.LANGUAGE, Constant.DEFAULT), this)
                 count++
             }
         } else {

--- a/app/src/main/res/values/array.xml
+++ b/app/src/main/res/values/array.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string-array name="languagentries">
-        <item>Default</item>
         <item>English</item>
         <item>German</item>
         <item>Spanish</item>
         <item>French</item>
         <item>Italian</item>
+        <item>Hindi</item>
     </string-array>
 
     <string-array name="languagentry">
-        <item>default</item>
         <item>en</item>
         <item>de</item>
         <item>es</item>
         <item>fr</item>
         <item>it</item>
+        <item>hi</item>
     </string-array>
 </resources>


### PR DESCRIPTION
Fixes #1142 

Changes: Now the skills are shown in the skill listing activity in the language chosen by the user.

**Example : When the user chooses Hindi from Settings**

![screenshot_1530078811](https://user-images.githubusercontent.com/30979369/41955178-9259870e-79fc-11e8-9444-6bf719fee23d.png)
