### PR TITLE
fix: Display audio and video action on history fetch

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatPresenter.kt
@@ -230,6 +230,7 @@ class ChatPresenter(chatActivity: ChatActivity) : IChatPresenter, IChatModel.OnR
                                     isHavingLink = psh.isHavingLink,
                                     datumList = psh.datumList,
                                     webSearch = psh.webSearch,
+                                    identifier = psh.identifier,
                                     skillLocation = allMessages[i].answers[0].skills[0]),
                                     this)
                         } catch (e: Exception) {


### PR DESCRIPTION
Fixes #1474 

Changes: Audio and video actions are fetched after the chathistory is retrieved

