### PR TITLE
Language Crash Fix

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -222,10 +222,17 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
     }
 
     private fun setLanguage() {
-        if (querylanguage.entries.isNotEmpty()) {
-            val index = querylanguage.findIndexOfValue(PrefManager.getString(Constant.LANGUAGE, Constant.DEFAULT))
-            querylanguage.setValueIndex(index)
-            querylanguage.summary = querylanguage.entries[index]
+        try {
+            if (querylanguage.entries.isNotEmpty()) {
+                val index = querylanguage.findIndexOfValue(PrefManager.getString(Constant.LANGUAGE, Constant.DEFAULT))
+                querylanguage.setValueIndex(index)
+                querylanguage.summary = querylanguage.entries[index]
+            }
+        } catch (e: Exception) {
+            Timber.e(e) //Language not present in app
+            PrefManager.putString(Constant.LANGUAGE, Constant.DEFAULT)
+            querylanguage.setValueIndex(0)//setting language to default - english
+            querylanguage.summary = querylanguage.entries[0]
         }
     }
 


### PR DESCRIPTION
Fixes #1478

Changes: Setting the default to en for all users, if the language is not present in the list preference.

@batbrain7 @arundhati24 Check now!