### PR TITLE
Remove ellipsis at the end from the feedback text view (Fixed #1514)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
@@ -65,8 +65,6 @@ class FeedbackAdapter(val context: Context, val feedbackResponse: GetSkillFeedba
                         }
                         if (feedbackResponse.feedbackList[position].feedback != null &&
                                 !TextUtils.isEmpty(feedbackResponse.feedbackList[position].feedback)) {
-                            holder.feedback.maxLines = 1
-                            holder.feedback.ellipsize = TextUtils.TruncateAt.END
                             holder.feedback.text = feedbackResponse.feedbackList[position].feedback
                         }
                     }


### PR DESCRIPTION
Fixes #1514 
Changes: Removed ellipsis at the end of the feedback text in the skill details screen.

**Screenshots for the change**

**Before**

![screenshot_1531294913](https://user-images.githubusercontent.com/30979369/42557826-25c3a7d4-850d-11e8-9224-347957512f4f.png)


**After**

![screenshot_1531294992](https://user-images.githubusercontent.com/30979369/42557839-30b737dc-850d-11e8-8c17-caa054d2cb1e.png)
