### PR TITLE
Show skills based on metrics in the skills listing fragment

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/data/SkillListingModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/SkillListingModel.kt
@@ -1,9 +1,11 @@
 package org.fossasia.susi.ai.data
 
 import org.fossasia.susi.ai.data.contract.ISkillListingModel
+import org.fossasia.susi.ai.dataclasses.SkillMetricsDataQuery
 import org.fossasia.susi.ai.dataclasses.SkillsListQuery
 import org.fossasia.susi.ai.rest.ClientBuilder
 import org.fossasia.susi.ai.rest.responses.susi.ListGroupsResponse
+import org.fossasia.susi.ai.rest.responses.susi.ListSkillMetricsResponse
 import org.fossasia.susi.ai.rest.responses.susi.ListSkillsResponse
 import retrofit2.Call
 import retrofit2.Callback
@@ -18,6 +20,7 @@ class SkillListingModel : ISkillListingModel {
 
     private lateinit var authResponseCallGroups: Call<ListGroupsResponse>
     private lateinit var authResponseCallSkills: Call<ListSkillsResponse>
+    private lateinit var authResponseCallMetrics: Call<ListSkillMetricsResponse>
 
     private var clientBuilder: ClientBuilder = ClientBuilder()
 
@@ -54,10 +57,27 @@ class SkillListingModel : ISkillListingModel {
         })
     }
 
+    override fun fetchSkillMetrics(query: SkillMetricsDataQuery, listener: ISkillListingModel.OnFetchSkillMetricsFinishedListener) {
+
+        authResponseCallMetrics = ClientBuilder.fetchListSkillMetricsCall(query)
+
+        authResponseCallMetrics.enqueue(object : Callback<ListSkillMetricsResponse> {
+            override fun onResponse(call: Call<ListSkillMetricsResponse>, response: Response<ListSkillMetricsResponse>) {
+                listener.onSkillMetricsFetchSuccess(response)
+            }
+
+            override fun onFailure(call: Call<ListSkillMetricsResponse>, t: Throwable) {
+                Timber.e(t)
+                listener.onSkillMetricsFetchFailure(t)
+            }
+        })
+    }
+
     override fun cancelFetch() {
         try {
             authResponseCallGroups.cancel()
             authResponseCallSkills.cancel()
+            authResponseCallMetrics.cancel()
         } catch (e: Exception) {
             Timber.e(e)
         }

--- a/app/src/main/java/org/fossasia/susi/ai/data/contract/ISkillListingModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/contract/ISkillListingModel.kt
@@ -1,6 +1,8 @@
 package org.fossasia.susi.ai.data.contract
 
+import org.fossasia.susi.ai.dataclasses.SkillMetricsDataQuery
 import org.fossasia.susi.ai.rest.responses.susi.ListGroupsResponse
+import org.fossasia.susi.ai.rest.responses.susi.ListSkillMetricsResponse
 import org.fossasia.susi.ai.rest.responses.susi.ListSkillsResponse
 import retrofit2.Response
 
@@ -19,9 +21,16 @@ interface ISkillListingModel {
         fun onSkillFetchFailure(t: Throwable)
     }
 
+    interface OnFetchSkillMetricsFinishedListener {
+        fun onSkillMetricsFetchSuccess(response: Response<ListSkillMetricsResponse>)
+        fun onSkillMetricsFetchFailure(t: Throwable)
+    }
+
     fun fetchGroups(listener: OnFetchGroupsFinishedListener)
 
     fun fetchSkills(group: String, language: String, listener: OnFetchSkillsFinishedListener)
+
+    fun fetchSkillMetrics(query: SkillMetricsDataQuery, listener: OnFetchSkillMetricsFinishedListener)
 
     fun cancelFetch()
 }

--- a/app/src/main/java/org/fossasia/susi/ai/dataclasses/SkillMetricsDataQuery.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/dataclasses/SkillMetricsDataQuery.kt
@@ -1,0 +1,10 @@
+package org.fossasia.susi.ai.dataclasses
+
+/**
+ *
+ * Created by arundhati24 on 12/07/2018
+ */
+data class SkillMetricsDataQuery(
+        val model: String = "",
+        val language: String = ""
+)

--- a/app/src/main/java/org/fossasia/susi/ai/dataclasses/SkillsBasedOnMetrics.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/dataclasses/SkillsBasedOnMetrics.kt
@@ -1,0 +1,12 @@
+package org.fossasia.susi.ai.dataclasses
+
+import org.fossasia.susi.ai.rest.responses.susi.SkillData
+
+/**
+ *
+ * Created by arundhati24 on 12/07/2018.
+ */
+data class SkillsBasedOnMetrics(
+        var metricsList: ArrayList<List<SkillData>?>,
+        var metricsGroupTitles: ArrayList<String>
+)

--- a/app/src/main/java/org/fossasia/susi/ai/rest/ClientBuilder.java
+++ b/app/src/main/java/org/fossasia/susi/ai/rest/ClientBuilder.java
@@ -1,10 +1,12 @@
 package org.fossasia.susi.ai.rest;
 
+import org.fossasia.susi.ai.dataclasses.SkillMetricsDataQuery;
 import org.fossasia.susi.ai.dataclasses.SkillRatingQuery;
 import org.fossasia.susi.ai.dataclasses.SkillsListQuery;
 import org.fossasia.susi.ai.dataclasses.FetchFeedbackQuery;
 import org.fossasia.susi.ai.helper.PrefManager;
 import org.fossasia.susi.ai.rest.interceptors.TokenInterceptor;
+import org.fossasia.susi.ai.rest.responses.susi.ListSkillMetricsResponse;
 import org.fossasia.susi.ai.rest.responses.susi.ListSkillsResponse;
 import org.fossasia.susi.ai.rest.responses.susi.SkillRatingResponse;
 import org.fossasia.susi.ai.rest.responses.susi.GetSkillFeedbackResponse;
@@ -78,7 +80,7 @@ public class ClientBuilder {
         return susiService;
     }
 
-    public static Call<GetSkillFeedbackResponse> fetchFeedbackCall(FetchFeedbackQuery queryObject){
+    public static Call<GetSkillFeedbackResponse> fetchFeedbackCall(FetchFeedbackQuery queryObject) {
         Map<String, String> queryMap = new HashMap<String, String>();
         queryMap.put("model", queryObject.getModel());
         queryMap.put("group", queryObject.getGroup());
@@ -88,7 +90,7 @@ public class ClientBuilder {
     }
 
     public static Call<SkillRatingResponse> rateSkillCall(SkillRatingQuery queryObject) {
-        Map<String, String> queryMap= new HashMap<String, String>();
+        Map<String, String> queryMap = new HashMap<String, String>();
         queryMap.put("model", queryObject.getModel());
         queryMap.put("group", queryObject.getGroup());
         queryMap.put("language", queryObject.getLanguage());
@@ -105,5 +107,9 @@ public class ClientBuilder {
         queryMap.put("filter_name", queryObject.getFilterName());
         queryMap.put("filter_type", queryObject.getFilterType());
         return susiService.fetchListSkills(queryMap);
+    }
+
+    public static Call<ListSkillMetricsResponse> fetchListSkillMetricsCall(SkillMetricsDataQuery queryObject) {
+        return susiService.fetchSkillMetricsData(queryObject.getModel(), queryObject.getLanguage());
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/rest/responses/susi/ListSkillMetricsResponse.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/rest/responses/susi/ListSkillMetricsResponse.kt
@@ -1,0 +1,15 @@
+package org.fossasia.susi.ai.rest.responses.susi
+
+/**
+ *
+ * Created by arundhati24 on 12/07/2018
+ */
+class ListSkillMetricsResponse {
+    val session: Session? = null
+    val accepted: Boolean = false
+    val message: String = ""
+    val group: String = ""
+    val model: String = ""
+    val language: String = ""
+    val metrics: Metrics? = null
+}

--- a/app/src/main/java/org/fossasia/susi/ai/rest/responses/susi/Metrics.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/rest/responses/susi/Metrics.kt
@@ -1,0 +1,12 @@
+package org.fossasia.susi.ai.rest.responses.susi
+
+/**
+ *
+ * Created by arundhati24 on 12/07/2018
+ */
+class Metrics {
+    val feedback: List<SkillData> = ArrayList()
+    val usage: List<SkillData> = ArrayList()
+    val rating: List<SkillData> = ArrayList()
+    val latest: List<SkillData> = ArrayList()
+}

--- a/app/src/main/java/org/fossasia/susi/ai/rest/services/SusiService.java
+++ b/app/src/main/java/org/fossasia/susi/ai/rest/services/SusiService.java
@@ -7,6 +7,7 @@ import org.fossasia.susi.ai.rest.responses.susi.ForgotPasswordResponse;
 import org.fossasia.susi.ai.rest.responses.susi.GetRatingByUserResponse;
 import org.fossasia.susi.ai.rest.responses.susi.GetSkillFeedbackResponse;
 import org.fossasia.susi.ai.rest.responses.susi.ListGroupsResponse;
+import org.fossasia.susi.ai.rest.responses.susi.ListSkillMetricsResponse;
 import org.fossasia.susi.ai.rest.responses.susi.ListSkillsResponse;
 import org.fossasia.susi.ai.rest.responses.susi.LoginResponse;
 import org.fossasia.susi.ai.rest.responses.susi.MemoryResponse;
@@ -202,5 +203,16 @@ public interface SusiService {
      */
     @GET("/cms/getSkillFeedback.json")
     Call<GetSkillFeedbackResponse> fetchFeedback(@QueryMap Map<String, String> query);
+
+    /**
+     * Get skills based on different metrics from the server
+     *
+     * @param model    Model of the skill (e.g. general)
+     * @param language Language directory in which the skill resides (e.g. en)
+     * @return the call
+     */
+    @GET("/cms/getSkillMetricsData.json")
+    Call<ListSkillMetricsResponse> fetchSkillMetricsData(@Query("model") String model,
+                                                         @Query("language") String language);
 
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
@@ -173,13 +173,13 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
 
         for ((pos, item) in skills.withIndex()) {
             if (query in item.first) {
-                skillGroups.scrollToPosition(pos)
+                skillMetrics.scrollToPosition(pos)
                 return true
             }
 
             for (item2 in item.second) {
                 if (query.toLowerCase() in item2.group.toLowerCase()) {
-                    skillGroups.scrollToPosition(pos)
+                    skillMetrics.scrollToPosition(pos)
                     return true
                 }
             }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
@@ -12,11 +12,12 @@ import android.view.View
 import android.view.ViewGroup
 import kotlinx.android.synthetic.main.fragment_skill_listing.*
 import org.fossasia.susi.ai.R
+import org.fossasia.susi.ai.dataclasses.SkillsBasedOnMetrics
 import org.fossasia.susi.ai.helper.StartSnapHelper
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
 import org.fossasia.susi.ai.skills.SkillFragmentCallback
 import org.fossasia.susi.ai.skills.SkillsActivity
-import org.fossasia.susi.ai.skills.skilllisting.adapters.recycleradapters.SkillGroupAdapter
+import org.fossasia.susi.ai.skills.skilllisting.adapters.recycleradapters.SkillMetricsAdapter
 import org.fossasia.susi.ai.skills.skilllisting.contract.ISkillListingPresenter
 import org.fossasia.susi.ai.skills.skilllisting.contract.ISkillListingView
 
@@ -29,7 +30,8 @@ class SkillListingFragment : Fragment(), ISkillListingView, SwipeRefreshLayout.O
     private lateinit var skillAdapterSnapHelper: SnapHelper
     private lateinit var skillListingPresenter: ISkillListingPresenter
     var skills: ArrayList<Pair<String, List<SkillData>>> = ArrayList()
-    private lateinit var skillGroupAdapter: SkillGroupAdapter
+    private var metrics = SkillsBasedOnMetrics(ArrayList(), ArrayList())
+    private lateinit var skillMetricsAdapter: SkillMetricsAdapter
     private lateinit var skillCallback: SkillFragmentCallback
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
@@ -39,11 +41,11 @@ class SkillListingFragment : Fragment(), ISkillListingView, SwipeRefreshLayout.O
     @NonNull
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         (activity as SkillsActivity).title = (activity as SkillsActivity).getString(R.string.skills_activity)
-        skillListingPresenter = SkillListingPresenter()
+        skillListingPresenter = SkillListingPresenter(this)
         skillListingPresenter.onAttach(this)
         swipe_refresh_layout.setOnRefreshListener(this)
         setUPAdapter()
-        skillListingPresenter.getGroups(swipe_refresh_layout.isRefreshing)
+        skillListingPresenter.getMetrics(swipe_refresh_layout.isRefreshing)
         super.onViewCreated(view, savedInstanceState)
     }
 
@@ -51,11 +53,11 @@ class SkillListingFragment : Fragment(), ISkillListingView, SwipeRefreshLayout.O
         skillAdapterSnapHelper = StartSnapHelper()
         val mLayoutManager = LinearLayoutManager(activity)
         mLayoutManager.orientation = LinearLayoutManager.VERTICAL
-        skillGroups.layoutManager = mLayoutManager
-        skillGroupAdapter = SkillGroupAdapter(requireContext(), skills, skillCallback)
-        skillGroups.adapter = skillGroupAdapter
-        skillGroups.onFlingListener = null
-        skillAdapterSnapHelper.attachToRecyclerView(skillGroups)
+        skillMetrics.layoutManager = mLayoutManager
+        skillMetricsAdapter = SkillMetricsAdapter(requireContext(), metrics, skillCallback)
+        skillMetrics.adapter = skillMetricsAdapter
+        skillMetrics.onFlingListener = null
+        skillAdapterSnapHelper.attachToRecyclerView(skillMetrics)
     }
 
     override fun visibilityProgressBar(boolean: Boolean) {
@@ -65,25 +67,27 @@ class SkillListingFragment : Fragment(), ISkillListingView, SwipeRefreshLayout.O
     override fun displayError() {
         if (activity != null) {
             swipe_refresh_layout.isRefreshing = false
-            skillGroups.visibility = View.GONE
+            skillMetrics.visibility = View.GONE
             errorSkillFetch.visibility = View.VISIBLE
         }
     }
 
-    override fun updateAdapter(skills: ArrayList<Pair<String, List<SkillData>>>) {
+    override fun updateAdapter(metrics: SkillsBasedOnMetrics) {
         swipe_refresh_layout.isRefreshing = false
         if (errorSkillFetch.visibility == View.VISIBLE) {
             errorSkillFetch.visibility = View.GONE
         }
-        skillGroups.visibility = View.VISIBLE
-        this.skills.clear()
-        this.skills.addAll(skills)
-        skillGroupAdapter.notifyDataSetChanged()
+        skillMetrics.visibility = View.VISIBLE
+        this.metrics.metricsList.clear()
+        this.metrics.metricsGroupTitles.clear()
+        this.metrics.metricsList.addAll(metrics.metricsList)
+        this.metrics.metricsGroupTitles.addAll(metrics.metricsGroupTitles)
+        skillMetricsAdapter.notifyDataSetChanged()
     }
 
     override fun onRefresh() {
         setUPAdapter()
-        skillListingPresenter.getGroups(swipe_refresh_layout.isRefreshing)
+        skillListingPresenter.getMetrics(swipe_refresh_layout.isRefreshing)
     }
 
     override fun onAttach(context: Context) {

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
@@ -1,12 +1,14 @@
 package org.fossasia.susi.ai.skills.skilllisting
 
+import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.data.SkillListingModel
+import org.fossasia.susi.ai.data.UtilModel
 import org.fossasia.susi.ai.data.contract.ISkillListingModel
+import org.fossasia.susi.ai.dataclasses.SkillMetricsDataQuery
+import org.fossasia.susi.ai.dataclasses.SkillsBasedOnMetrics
 import org.fossasia.susi.ai.helper.Constant
 import org.fossasia.susi.ai.helper.PrefManager
-import org.fossasia.susi.ai.rest.responses.susi.ListGroupsResponse
-import org.fossasia.susi.ai.rest.responses.susi.ListSkillsResponse
-import org.fossasia.susi.ai.rest.responses.susi.SkillData
+import org.fossasia.susi.ai.rest.responses.susi.*
 import org.fossasia.susi.ai.skills.skilllisting.contract.ISkillListingPresenter
 import org.fossasia.susi.ai.skills.skilllisting.contract.ISkillListingView
 import retrofit2.Response
@@ -17,15 +19,18 @@ import timber.log.Timber
  *
  * Created by chiragw15 on 15/8/17.
  */
-class SkillListingPresenter : ISkillListingPresenter,
-        ISkillListingModel.OnFetchGroupsFinishedListener, ISkillListingModel.OnFetchSkillsFinishedListener {
+class SkillListingPresenter(val skillListingFragment: SkillListingFragment) : ISkillListingPresenter, ISkillListingModel.OnFetchGroupsFinishedListener,
+        ISkillListingModel.OnFetchSkillsFinishedListener, ISkillListingModel.OnFetchSkillMetricsFinishedListener {
 
     private var skillListingModel: ISkillListingModel = SkillListingModel()
     private var skillListingView: ISkillListingView? = null
     private var count = 1
-    var skills: ArrayList<Pair<String, List<SkillData>>> = ArrayList()
+    private var skills: ArrayList<Pair<String, List<SkillData>>> = ArrayList()
+    private var metrics = SkillsBasedOnMetrics(ArrayList(), ArrayList())
+    private var metricsData: Metrics? = null
     private var groupsCount = 0
     private var groups: List<String> = ArrayList()
+    private val utilModel = UtilModel(skillListingFragment.requireContext())
 
     override fun onAttach(skillListingView: ISkillListingView) {
         this.skillListingView = skillListingView
@@ -34,6 +39,12 @@ class SkillListingPresenter : ISkillListingPresenter,
     override fun getGroups(swipeToRefreshActive: Boolean) {
         skillListingView?.visibilityProgressBar(true)
         skillListingModel.fetchGroups(this)
+    }
+
+    override fun getMetrics(swipeToRefreshActive: Boolean) {
+        skillListingView?.visibilityProgressBar(true)
+        val queryObject = SkillMetricsDataQuery("general", PrefManager.getString(Constant.LANGUAGE, Constant.DEFAULT))
+        skillListingModel.fetchSkillMetrics(queryObject, this)
     }
 
     override fun onGroupFetchSuccess(response: Response<ListGroupsResponse>) {
@@ -61,7 +72,7 @@ class SkillListingPresenter : ISkillListingPresenter,
             val responseSkillMap = response.body().filteredSkillsData
             if (responseSkillMap.isNotEmpty()) {
                 skills.add(Pair(group, responseSkillMap))
-                skillListingView?.updateAdapter(skills)
+                //skillListingView?.updateAdapter(skills)
             }
             if (count != groupsCount) {
                 skillListingModel.fetchSkills(groups[count], PrefManager.getString(Constant.LANGUAGE, Constant.DEFAULT), this)
@@ -75,6 +86,57 @@ class SkillListingPresenter : ISkillListingPresenter,
     }
 
     override fun onSkillFetchFailure(t: Throwable) {
+        skillListingView?.visibilityProgressBar(false)
+        skillListingView?.displayError()
+    }
+
+    override fun onSkillMetricsFetchSuccess(response: Response<ListSkillMetricsResponse>) {
+        skillListingView?.visibilityProgressBar(false)
+        if (response.isSuccessful && response.body() != null) {
+            Timber.d("METRICS FETCHED")
+            metricsData = response.body().metrics
+            if (metricsData != null) {
+                metrics.metricsList.clear()
+                if (metricsData?.rating != null) {
+                    if (metricsData?.rating?.size as Int > 0) {
+                        metrics.metricsGroupTitles.add(utilModel.getString(R.string.metric_rating))
+                        metrics.metricsList.add(metricsData?.rating)
+                        skillListingView?.updateAdapter(metrics)
+                    }
+                }
+
+                if (metricsData?.usage != null) {
+                    if (metricsData?.usage?.size as Int > 0) {
+                        metrics.metricsGroupTitles.add(utilModel.getString(R.string.metric_usage))
+                        metrics.metricsList.add(metricsData?.usage)
+                        skillListingView?.updateAdapter(metrics)
+                    }
+                }
+
+                if (metricsData?.latest != null) {
+                    if (metricsData?.latest?.size as Int > 0) {
+                        metrics.metricsGroupTitles.add(utilModel.getString(R.string.metric_latest))
+                        metrics.metricsList.add(metricsData?.latest)
+                        skillListingView?.updateAdapter(metrics)
+                    }
+                }
+
+                if (metricsData?.feedback != null) {
+                    if (metricsData?.feedback?.size as Int > 0) {
+                        metrics.metricsGroupTitles.add(utilModel.getString(R.string.metric_feedback))
+                        metrics.metricsList.add(metricsData?.feedback)
+                        skillListingView?.updateAdapter(metrics)
+                    }
+                }
+            }
+        } else {
+            Timber.d("METRICS NOT FETCHED")
+            skillListingView?.visibilityProgressBar(false)
+            skillListingView?.displayError()
+        }
+    }
+
+    override fun onSkillMetricsFetchFailure(t: Throwable) {
         skillListingView?.visibilityProgressBar(false)
         skillListingView?.displayError()
     }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
@@ -15,7 +15,7 @@ import org.fossasia.susi.ai.skills.skilllisting.adapters.viewholders.SkillViewHo
  *
  * Created by chiragw15 on 15/8/17.
  */
-class SkillListAdapter(val context: Context, private val skillDetails: Pair<String, List<SkillData>>, val skillCallback: SkillFragmentCallback) : RecyclerView.Adapter<SkillViewHolder>(),
+class SkillListAdapter(val context: Context, private val skillDetails: List<SkillData>?, val skillCallback: SkillFragmentCallback) : RecyclerView.Adapter<SkillViewHolder>(),
         SkillViewHolder.ClickListener {
 
     private val imageLink = "https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/general/"
@@ -23,56 +23,58 @@ class SkillListAdapter(val context: Context, private val skillDetails: Pair<Stri
 
     @NonNull
     override fun onBindViewHolder(holder: SkillViewHolder, position: Int) {
-        val skillData = skillDetails.second.toTypedArray()[position]
+        if (skillDetails != null) {
+            val skillData = skillDetails.toTypedArray()[position]
 
-        if (skillData.skillName == null || skillData.skillName.isEmpty()) {
-            holder.skillPreviewTitle?.text = context.getString(R.string.no_skill_name)
-        } else {
-            holder.skillPreviewTitle?.text = skillData.skillName
-        }
+            if (skillData.skillName == null || skillData.skillName.isEmpty()) {
+                holder.skillPreviewTitle?.text = context.getString(R.string.no_skill_name)
+            } else {
+                holder.skillPreviewTitle?.text = skillData.skillName
+            }
 
-        if (skillData.descriptions == null || skillData.descriptions.isEmpty()) {
-            holder.skillPreviewDescription?.text = context.getString(R.string.no_skill_description)
-        } else {
-            holder.skillPreviewDescription?.text = skillData.descriptions
-        }
+            if (skillData.descriptions == null || skillData.descriptions.isEmpty()) {
+                holder.skillPreviewDescription?.text = context.getString(R.string.no_skill_description)
+            } else {
+                holder.skillPreviewDescription?.text = skillData.descriptions
+            }
 
-        if (skillData.examples == null || skillData.examples.isEmpty())
-            holder.skillPreviewExample?.text = StringBuilder("\"").append("\"")
-        else
-            holder.skillPreviewExample?.text = StringBuilder("\"").append(skillData.examples[0]).append("\"")
+            if (skillData.examples == null || skillData.examples.isEmpty())
+                holder.skillPreviewExample?.text = StringBuilder("\"").append("\"")
+            else
+                holder.skillPreviewExample?.text = StringBuilder("\"").append(skillData.examples[0]).append("\"")
 
-        if (skillData.image == null || skillData.image.isEmpty()) {
-            holder.previewImageView?.setImageResource(R.drawable.ic_susi)
-        } else {
-            Picasso.with(context.applicationContext).load(StringBuilder(imageLink)
-                    .append(skillDetails.first.replace(" ", "%20")).append("/en/").append(skillData.image).toString())
-                    .fit().centerCrop()
-                    .error(R.drawable.ic_susi)
-                    .into(holder.previewImageView)
-        }
+            if (skillData.image == null || skillData.image.isEmpty()) {
+                holder.previewImageView?.setImageResource(R.drawable.ic_susi)
+            } else {
+                Picasso.with(context.applicationContext).load(StringBuilder(imageLink)
+                        .append(skillDetails[position].group.replace(" ", "%20")).append("/en/").append(skillData.image).toString())
+                        .fit().centerCrop()
+                        .error(R.drawable.ic_susi)
+                        .into(holder.previewImageView)
+            }
 
-        if (skillData.skillRating != null) {
-            if (skillData.skillRating?.stars != null) {
-                holder.skillRatingBar.rating = skillData.skillRating?.stars?.averageStar as Float
-                holder.totalRatings.text = skillData.skillRating?.stars?.totalStar.toString()
+            if (skillData.skillRating != null) {
+                if (skillData.skillRating?.stars != null) {
+                    holder.skillRatingBar.rating = skillData.skillRating?.stars?.averageStar as Float
+                    holder.totalRatings.text = skillData.skillRating?.stars?.totalStar.toString()
+                }
             }
         }
     }
 
     override fun getItemCount(): Int {
-        return skillDetails.second.size
+        return (skillDetails as List<SkillData>).size
     }
 
     override fun onItemClicked(position: Int) {
         var skillTag: String? = ""
-        if (skillDetails.second.toTypedArray()[position].skillTag != null) {
-            skillTag = skillDetails.second.toTypedArray()[position].skillTag
+        if ((skillDetails as List<SkillData>)[position].skillTag != null) {
+            skillTag = skillDetails.toTypedArray()[position].skillTag
         } else {
             skillTag = ""
         }
-        val skillData = skillDetails.second.toTypedArray()[position]
-        val skillGroup = skillDetails.first.replace(" ", "%20")
+        val skillData = skillDetails[position]
+        val skillGroup = skillDetails[position].group.replace(" ", "%20")
         showSkillDetailFragment(skillData, skillGroup, skillTag)
     }
 

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillMetricsAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillMetricsAdapter.kt
@@ -16,25 +16,27 @@ import org.fossasia.susi.ai.skills.skilllisting.adapters.viewholders.GroupViewHo
 
 /**
  *
- * Created by chiragw15 on 15/8/17.
+ * Created by arundhati24 on 27/07/2018.
  */
-class SkillGroupAdapter(val context: Context, val metrics: SkillsBasedOnMetrics, val skillCallback: SkillFragmentCallback)
+class SkillMetricsAdapter(val context: Context, val metrics: SkillsBasedOnMetrics, val skillCallback: SkillFragmentCallback)
     : RecyclerView.Adapter<GroupViewHolder>() {
 
     private lateinit var skillAdapterSnapHelper: SnapHelper
 
     @NonNull
     override fun onBindViewHolder(holder: GroupViewHolder, position: Int) {
-        if (metrics.metricsList[position] != null)
-            holder.groupName?.text = metrics.metricsGroupTitles[position]
+        if (metrics != null) {
+            if (metrics.metricsGroupTitles[position] != null)
+                holder.groupName?.text = metrics.metricsGroupTitles[position]
 
-        skillAdapterSnapHelper = StartSnapHelper()
-        holder.skillList?.setHasFixedSize(true)
-        val mLayoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
-        holder.skillList?.layoutManager = mLayoutManager
-        holder.skillList?.adapter = SkillListAdapter(context, metrics.metricsList[position], skillCallback)
-        holder.skillList?.onFlingListener = null
-        skillAdapterSnapHelper.attachToRecyclerView(holder.skillList)
+            skillAdapterSnapHelper = StartSnapHelper()
+            holder.skillList?.setHasFixedSize(true)
+            val mLayoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
+            holder.skillList?.layoutManager = mLayoutManager
+            holder.skillList?.adapter = SkillListAdapter(context, metrics.metricsList[position], skillCallback)
+            holder.skillList?.onFlingListener = null
+            skillAdapterSnapHelper.attachToRecyclerView(holder.skillList)
+        }
     }
 
     override fun getItemCount(): Int {

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/contract/ISkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/contract/ISkillListingPresenter.kt
@@ -7,5 +7,6 @@ package org.fossasia.susi.ai.skills.skilllisting.contract
 interface ISkillListingPresenter {
     fun onAttach(skillListingView: ISkillListingView)
     fun getGroups(swipeToRefreshActive: Boolean)
+    fun getMetrics(swipeToRefreshActive: Boolean)
     fun onDetach()
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/contract/ISkillListingView.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/contract/ISkillListingView.kt
@@ -1,5 +1,6 @@
 package org.fossasia.susi.ai.skills.skilllisting.contract
 
+import org.fossasia.susi.ai.dataclasses.SkillsBasedOnMetrics
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
 
 /**
@@ -8,6 +9,6 @@ import org.fossasia.susi.ai.rest.responses.susi.SkillData
  */
 interface ISkillListingView {
     fun visibilityProgressBar(boolean: Boolean)
-    fun updateAdapter(skills: ArrayList<Pair<String, List<SkillData>>>)
+    fun updateAdapter(metrics: SkillsBasedOnMetrics)
     fun displayError()
 }

--- a/app/src/main/res/layout/fragment_skill_listing.xml
+++ b/app/src/main/res/layout/fragment_skill_listing.xml
@@ -10,7 +10,7 @@
         android:background="@color/default_bg">
 
         <android.support.v7.widget.RecyclerView
-            android:id="@+id/skillGroups"
+            android:id="@+id/skillMetrics"
             android:layout_width="match_parent"
             android:layout_height="match_parent" />
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -378,4 +378,11 @@
     <!-- TODO: Remove or change this placeholder text -->
     <string name="hello_blank_fragment">Hello blank fragment</string>
 
+    <!-- Metrics -->
+
+    <string name="metric_rating">\"SUSI, What are your highest rated skills?\"</string>
+    <string name="metric_usage">\"SUSI, what are your most used skills?\"</string>
+    <string name="metric_latest">\"SUSI, what are the latest skills?\"</string>
+    <string name="metric_feedback">\"SUSI, what are the skills with most feedback?\"</string>
+
 </resources>


### PR DESCRIPTION
Fixes #1517 

Changes: Now, the skills are shown in the skills activity based on various metrics like feedback, usage, rating and latest. This reduces the number of API calls (which was equal to the number of groups 
\+ 1 earlier) to just one API call i.e. from the getSkillMetricsData.json.

**Screenshot for current UI**

![metricsskills](https://user-images.githubusercontent.com/30979369/42617074-17c15a5c-85ce-11e8-8e01-a25ea1fd74b8.png)

