### PR TITLE
Show skills according to the group chosen by the user (Fixed #1539)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/data/GroupWiseSkillsModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/GroupWiseSkillsModel.kt
@@ -1,0 +1,43 @@
+package org.fossasia.susi.ai.data
+
+import org.fossasia.susi.ai.data.contract.IGroupWiseSkillsModel
+import org.fossasia.susi.ai.dataclasses.SkillsListQuery
+import org.fossasia.susi.ai.rest.ClientBuilder
+import org.fossasia.susi.ai.rest.responses.susi.ListSkillsResponse
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+import timber.log.Timber
+
+/**
+ *
+ * Created by arundhati24 on 16/07/2018.
+ */
+class GroupWiseSkillsModel : IGroupWiseSkillsModel {
+
+    private lateinit var authResponseCallSkills: Call<ListSkillsResponse>
+
+    override fun fetchSkills(group: String, language: String, listener: IGroupWiseSkillsModel.OnFetchSkillsFinishedListener) {
+        val queryObject = SkillsListQuery(group, language, "true", "descending", "rating")
+        authResponseCallSkills = ClientBuilder.fetchListSkillsCall(queryObject)
+
+        authResponseCallSkills.enqueue(object : Callback<ListSkillsResponse> {
+            override fun onResponse(call: Call<ListSkillsResponse>, response: Response<ListSkillsResponse>) {
+                listener.onSkillFetchSuccess(response, group)
+            }
+
+            override fun onFailure(call: Call<ListSkillsResponse>, t: Throwable) {
+                Timber.e(t)
+                listener.onSkillFetchFailure(t)
+            }
+        })
+    }
+
+    override fun cancelFetch() {
+        try {
+            authResponseCallSkills.cancel()
+        } catch (e: Exception) {
+            Timber.e(e)
+        }
+    }
+}

--- a/app/src/main/java/org/fossasia/susi/ai/data/contract/IGroupWiseSkillsModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/contract/IGroupWiseSkillsModel.kt
@@ -1,0 +1,19 @@
+package org.fossasia.susi.ai.data.contract
+
+import org.fossasia.susi.ai.rest.responses.susi.ListSkillsResponse
+import retrofit2.Response
+
+/**
+ *
+ * Created by arundhati24 on 16/07/2018.
+ */
+interface IGroupWiseSkillsModel {
+    interface OnFetchSkillsFinishedListener {
+        fun onSkillFetchSuccess(response: Response<ListSkillsResponse>, group: String)
+        fun onSkillFetchFailure(t: Throwable)
+    }
+
+    fun fetchSkills(group: String, language: String, listener: OnFetchSkillsFinishedListener)
+
+    fun cancelFetch()
+}

--- a/app/src/main/java/org/fossasia/susi/ai/dataclasses/GroupWiseSkills.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/dataclasses/GroupWiseSkills.kt
@@ -1,0 +1,12 @@
+package org.fossasia.susi.ai.dataclasses
+
+import org.fossasia.susi.ai.rest.responses.susi.SkillData
+
+/**
+ *
+ * Created by arundhati24 on 16/07/2018.
+ */
+data class GroupWiseSkills(
+        var group: String,
+        var skillsList: MutableList<SkillData>
+)

--- a/app/src/main/java/org/fossasia/susi/ai/skills/SkillFragmentCallback.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/SkillFragmentCallback.kt
@@ -3,5 +3,8 @@ package org.fossasia.susi.ai.skills
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
 
 interface SkillFragmentCallback {
-     fun loadDetailFragment(skillData: SkillData, skillGroup: String, skillTag: String)
+
+    fun loadDetailFragment(skillData: SkillData, skillGroup: String, skillTag: String)
+
+    fun loadGroupWiseSkillsFragment(group: String)
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
@@ -17,6 +17,7 @@ import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.chat.ChatActivity
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
 import org.fossasia.susi.ai.skills.aboutus.AboutUsFragment
+import org.fossasia.susi.ai.skills.groupwiseskills.GroupWiseSkillsFragment
 import org.fossasia.susi.ai.skills.settings.ChatSettingsFragment
 import org.fossasia.susi.ai.skills.skilldetails.SkillDetailsFragment
 import org.fossasia.susi.ai.skills.skilllisting.SkillListingFragment
@@ -34,12 +35,14 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
     private val TAG_SETTINGS_FRAGMENT = "SettingsFragment"
     private val TAG_SKILLS_FRAGMENT = "SkillsFragment"
     private val TAG_ABOUT_FRAGMENT = "AboutUsFragment"
+    private val TAG_GROUP_WISE_SKILLS_FRAGMENT = "GroupWiseSkillsFragment"
 
     private var mSearchAction: MenuItem? = null
     private var isSearchOpened = false
     private var edtSearch: EditText? = null
     private var skills: ArrayList<Pair<String, List<SkillData>>> = ArrayList()
     private var text: String = ""
+    private var group: String = ""
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -60,9 +63,9 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
         return true
     }
 
-    private fun exitActivity() {
+    private fun exitActivity(context: Context) {
         overridePendingTransition(R.anim.trans_right_in, R.anim.trans_right_out)
-        val intent = Intent(this@SkillsActivity, ChatActivity::class.java)
+        val intent = Intent(context, ChatActivity::class.java)
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
         startActivity(intent)
     }
@@ -71,9 +74,11 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
         overridePendingTransition(R.anim.trans_right_in, R.anim.trans_right_out)
         if (supportFragmentManager.popBackStackImmediate(TAG_SKILLS_FRAGMENT, 0)) {
             title = getString(R.string.skills_activity)
+        } else if (supportFragmentManager.popBackStackImmediate(TAG_GROUP_WISE_SKILLS_FRAGMENT, 0)) {
+            title = getString(R.string.skills_activity)
         } else {
             finish()
-            exitActivity()
+            exitActivity(this)
         }
     }
 
@@ -205,6 +210,15 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
         (this).supportFragmentManager.beginTransaction()
                 .add(R.id.fragment_container, skillDetailsFragment)
                 .addToBackStack(SkillDetailsFragment().toString())
+                .commit()
+    }
+
+    override fun loadGroupWiseSkillsFragment(group: String) {
+        handleOnLoadingFragment()
+        val groupWiseSkillsFragment = GroupWiseSkillsFragment.newInstance(group)
+        (this).supportFragmentManager.beginTransaction()
+                .add(R.id.fragment_container, groupWiseSkillsFragment)
+                .addToBackStack(GroupWiseSkillsFragment().toString())
                 .commit()
     }
 

--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/GroupWiseSkillsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/GroupWiseSkillsFragment.kt
@@ -1,0 +1,105 @@
+package org.fossasia.susi.ai.skills.groupwiseskills
+
+import android.support.v4.app.Fragment
+import android.os.Bundle
+import android.support.annotation.NonNull
+import android.support.v4.widget.SwipeRefreshLayout
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.*
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import kotlinx.android.synthetic.main.fragment_group_wise_skill_listing.*
+import org.fossasia.susi.ai.R
+import org.fossasia.susi.ai.dataclasses.GroupWiseSkills
+import org.fossasia.susi.ai.helper.SimpleDividerItemDecoration
+import org.fossasia.susi.ai.helper.StartSnapHelper
+import org.fossasia.susi.ai.skills.groupwiseskills.adapters.recycleradapters.SkillsListAdapter
+import org.fossasia.susi.ai.skills.groupwiseskills.contract.IGroupWiseSkillsPresenter
+import org.fossasia.susi.ai.skills.groupwiseskills.contract.IGroupWiseSkillsView
+
+/**
+ *
+ * Created by arundhati24 on 16/07/2018.
+ */
+class GroupWiseSkillsFragment : Fragment(), IGroupWiseSkillsView, SwipeRefreshLayout.OnRefreshListener {
+    private lateinit var skillAdapterSnapHelper: SnapHelper
+    private lateinit var groupWiseSkillsPresenter: IGroupWiseSkillsPresenter
+    private var skills = GroupWiseSkills("", ArrayList())
+    private lateinit var skillsAdapter: SkillsListAdapter
+
+    companion object {
+        const val SKILL_GROUP = "group"
+        fun newInstance(group: String): GroupWiseSkillsFragment {
+            val fragment = GroupWiseSkillsFragment()
+            val bundle = Bundle()
+            bundle.putString(SKILL_GROUP, group)
+            fragment.arguments = bundle
+            return fragment
+        }
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        val argument = arguments
+        if (argument != null) {
+            this.skills.group = argument.getString("group")
+        }
+        return inflater.inflate(R.layout.fragment_group_wise_skill_listing, container, false)
+    }
+
+    @NonNull
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        activity?.title = activity?.getString(R.string.skills_activity)
+        groupWiseSkillsPresenter = GroupWiseSkillsPresenter(this)
+        groupWiseSkillsPresenter.onAttach(this)
+        swipeRefreshLayout.setOnRefreshListener(this)
+        setUPAdapter()
+        groupWiseSkillsPresenter.getSkills(swipeRefreshLayout.isRefreshing, skills.group)
+        super.onViewCreated(view, savedInstanceState)
+    }
+
+    private fun setUPAdapter() {
+        skillAdapterSnapHelper = StartSnapHelper()
+        val mLayoutManager = LinearLayoutManager(activity)
+        mLayoutManager.orientation = LinearLayoutManager.VERTICAL
+        groupWiseSkills.layoutManager = mLayoutManager
+        skillsAdapter = SkillsListAdapter(requireContext(), skills)
+        groupWiseSkills.adapter = skillsAdapter
+        groupWiseSkills.onFlingListener = null
+        skillAdapterSnapHelper.attachToRecyclerView(groupWiseSkills)
+    }
+
+    override fun visibilityProgressBar(boolean: Boolean) {
+        progressSkillWait.visibility = if (boolean) View.VISIBLE else View.GONE
+    }
+
+    override fun displayError() {
+        if (activity != null) {
+            swipeRefreshLayout.isRefreshing = false
+            groupWiseSkills.visibility = View.GONE
+            errorSkillFetch.visibility = View.VISIBLE
+        }
+    }
+
+    override fun updateAdapter(skills: GroupWiseSkills) {
+        swipeRefreshLayout.isRefreshing = false
+        if (errorSkillFetch.visibility == View.VISIBLE) {
+            errorSkillFetch.visibility = View.GONE
+        }
+        groupWiseSkills.visibility = View.VISIBLE
+        this.skills.skillsList.clear()
+        this.skills.skillsList.addAll(skills.skillsList)
+        groupWiseSkills.addItemDecoration(SimpleDividerItemDecoration(context, this.skills.skillsList.size))
+        skillsAdapter.notifyDataSetChanged()
+    }
+
+    override fun onRefresh() {
+        setUPAdapter()
+        groupWiseSkillsPresenter.getSkills(swipeRefreshLayout.isRefreshing, skills.group)
+    }
+
+    override fun onDestroyView() {
+        groupWiseSkillsPresenter.onDetach()
+        super.onDestroyView()
+    }
+}

--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/GroupWiseSkillsPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/GroupWiseSkillsPresenter.kt
@@ -1,0 +1,60 @@
+package org.fossasia.susi.ai.skills.groupwiseskills
+
+import org.fossasia.susi.ai.data.GroupWiseSkillsModel
+import org.fossasia.susi.ai.data.contract.IGroupWiseSkillsModel
+import org.fossasia.susi.ai.dataclasses.GroupWiseSkills
+import org.fossasia.susi.ai.helper.Constant
+import org.fossasia.susi.ai.helper.PrefManager
+import org.fossasia.susi.ai.rest.responses.susi.ListSkillsResponse
+import org.fossasia.susi.ai.rest.responses.susi.SkillData
+import org.fossasia.susi.ai.skills.groupwiseskills.contract.IGroupWiseSkillsPresenter
+import org.fossasia.susi.ai.skills.groupwiseskills.contract.IGroupWiseSkillsView
+import retrofit2.Response
+import timber.log.Timber
+
+/**
+ *
+ * Created by arundhati24 on 16/07/2018.
+ */
+class GroupWiseSkillsPresenter(val groupWiseSkillsFragment: GroupWiseSkillsFragment) : IGroupWiseSkillsPresenter,
+        IGroupWiseSkillsModel.OnFetchSkillsFinishedListener {
+    private var groupWiseSkillsModel: IGroupWiseSkillsModel = GroupWiseSkillsModel()
+    private var groupWiseSkillsView: IGroupWiseSkillsView? = null
+    private var skills = GroupWiseSkills("", ArrayList())
+
+    override fun onAttach(groupWiseSkillsView: IGroupWiseSkillsView) {
+        this.groupWiseSkillsView = groupWiseSkillsView
+    }
+
+    override fun getSkills(swipeToRefreshActive: Boolean, group: String) {
+        groupWiseSkillsView?.visibilityProgressBar(!swipeToRefreshActive)
+        groupWiseSkillsModel.fetchSkills(group, PrefManager.getString(Constant.LANGUAGE, Constant.DEFAULT), this)
+    }
+
+    override fun onSkillFetchSuccess(response: Response<ListSkillsResponse>, group: String) {
+        groupWiseSkillsView?.visibilityProgressBar(false)
+        if (response.isSuccessful && response.body() != null) {
+            Timber.d("GROUP WISE SKILLS FETCHED")
+            val responseSkillList = response.body().filteredSkillsData
+            if (responseSkillList != null && responseSkillList.isNotEmpty()) {
+                skills.skillsList.clear()
+                skills.skillsList = responseSkillList as MutableList<SkillData>
+                groupWiseSkillsView?.updateAdapter(skills)
+            }
+        } else {
+            Timber.d("GROUP WISE SKILLS NOT FETCHED")
+            groupWiseSkillsView?.visibilityProgressBar(false)
+            groupWiseSkillsView?.displayError()
+        }
+    }
+
+    override fun onSkillFetchFailure(t: Throwable) {
+        groupWiseSkillsView?.visibilityProgressBar(false)
+        groupWiseSkillsView?.displayError()
+    }
+
+    override fun onDetach() {
+        groupWiseSkillsModel.cancelFetch()
+        groupWiseSkillsView = null
+    }
+}

--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/recycleradapters/SkillsListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/recycleradapters/SkillsListAdapter.kt
@@ -1,0 +1,73 @@
+package org.fossasia.susi.ai.skills.groupwiseskills.adapters.recycleradapters
+
+import android.content.Context
+import android.support.annotation.NonNull
+import android.support.v7.widget.RecyclerView
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import com.squareup.picasso.Picasso
+import org.fossasia.susi.ai.R
+import org.fossasia.susi.ai.dataclasses.GroupWiseSkills
+import org.fossasia.susi.ai.skills.groupwiseskills.adapters.viewholders.SkillViewHolder
+
+/**
+ *
+ * Created by arundhati24 on 16/07/2018.
+ */
+class SkillsListAdapter(val context: Context, private val skillDetails: GroupWiseSkills) : RecyclerView.Adapter<SkillViewHolder>() {
+
+    private val imageLink = "https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/general/"
+
+    @NonNull
+    override fun onBindViewHolder(holder: SkillViewHolder, position: Int) {
+        if (skillDetails != null) {
+            val skillData = skillDetails.skillsList.get(position)
+
+            if (skillData.skillName == null || skillData.skillName.isEmpty()) {
+                holder.skillName?.text = context.getString(R.string.no_skill_name)
+            } else {
+                holder.skillName?.text = skillData.skillName
+            }
+
+            if (skillData.author == null || skillData.author.isEmpty()) {
+                holder.skillAuthorName?.text = context.getString(R.string.no_skill_author)
+            } else {
+                holder.skillAuthorName?.text = skillData.author
+            }
+
+            if (skillData.examples == null || skillData.examples.isEmpty())
+                holder.skillExample?.text = StringBuilder("\"").append("\"")
+            else
+                holder.skillExample?.text = StringBuilder("\"").append(skillData.examples[0]).append("\"")
+
+            if (skillData.image == null || skillData.image.isEmpty()) {
+                holder.skillImage?.setImageResource(R.drawable.ic_susi)
+            } else {
+                val imageUrl: String = skillDetails.skillsList.get(position).group.replace(" ", "%20") + "/en/" + skillData.image
+                Picasso.with(context.applicationContext).load(StringBuilder(imageLink)
+                        .append(imageUrl).toString())
+                        .fit().centerCrop()
+                        .error(R.drawable.ic_susi)
+                        .into(holder.skillImage)
+            }
+
+            if (skillData.skillRating != null) {
+                if (skillData.skillRating?.stars != null) {
+                    holder.skillRating?.rating = skillData.skillRating?.stars?.averageStar as Float
+                    holder.skillTotalRatings?.text = skillData.skillRating?.stars?.totalStar.toString()
+                }
+            }
+        }
+    }
+
+    override fun getItemCount(): Int {
+        return skillDetails.skillsList.size
+    }
+
+    @NonNull
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SkillViewHolder {
+        val itemView = LayoutInflater.from(parent.context)
+                .inflate(R.layout.item_group_wise_skill, parent, false)
+        return SkillViewHolder(itemView)
+    }
+}

--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/viewholders/SkillViewHolder.java
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/viewholders/SkillViewHolder.java
@@ -1,0 +1,36 @@
+package org.fossasia.susi.ai.skills.groupwiseskills.adapters.viewholders;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.RatingBar;
+import android.widget.TextView;
+
+import org.fossasia.susi.ai.R;
+
+import butterknife.BindView;
+import butterknife.ButterKnife;
+
+/**
+ * Created by arundhati24 on 16/07/2018.
+ */
+public class SkillViewHolder extends RecyclerView.ViewHolder {
+
+    @BindView(R.id.skill_image)
+    public ImageView skillImage;
+    @BindView(R.id.skill_name)
+    public TextView skillName;
+    @BindView(R.id.skill_author_name)
+    public TextView skillAuthorName;
+    @BindView(R.id.skill_example)
+    public TextView skillExample;
+    @BindView(R.id.skill_rating)
+    public RatingBar skillRating;
+    @BindView(R.id.skill_total_ratings)
+    public TextView skillTotalRatings;
+
+    public SkillViewHolder(View itemView) {
+        super(itemView);
+        ButterKnife.bind(this, itemView);
+    }
+}

--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/contract/IGroupWiseSkillsPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/contract/IGroupWiseSkillsPresenter.kt
@@ -1,0 +1,14 @@
+package org.fossasia.susi.ai.skills.groupwiseskills.contract
+
+/**
+ *
+ * Created by arundhati24 on 16/07/2018.
+ */
+interface IGroupWiseSkillsPresenter {
+
+    fun onAttach(groupWiseSkillsView: IGroupWiseSkillsView)
+
+    fun getSkills(swipeToRefreshActive: Boolean, group: String)
+
+    fun onDetach()
+}

--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/contract/IGroupWiseSkillsView.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/contract/IGroupWiseSkillsView.kt
@@ -1,0 +1,16 @@
+package org.fossasia.susi.ai.skills.groupwiseskills.contract
+
+import org.fossasia.susi.ai.dataclasses.GroupWiseSkills
+
+/**
+ *
+ * Created by arundhati24 on 16/07/2018.
+ */
+interface IGroupWiseSkillsView {
+
+    fun visibilityProgressBar(boolean: Boolean)
+
+    fun updateAdapter(skills: GroupWiseSkills)
+
+    fun displayError()
+}

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillMetricsAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillMetricsAdapter.kt
@@ -1,6 +1,5 @@
 package org.fossasia.susi.ai.skills.skilllisting.adapters.recycleradapters
 
-import android.annotation.TargetApi
 import android.content.Context
 import android.support.annotation.NonNull
 import android.support.v4.content.ContextCompat
@@ -21,12 +20,14 @@ import org.fossasia.susi.ai.skills.skilllisting.adapters.viewholders.SkillGroupV
  *
  * Created by arundhati24 on 12/07/2018.
  */
-class SkillMetricsAdapter(val context: Context, val metrics: SkillsBasedOnMetrics,
-                          val skillCallback: SkillFragmentCallback) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class SkillMetricsAdapter(val context: Context, val metrics: SkillsBasedOnMetrics, val skillCallback: SkillFragmentCallback) :
+        RecyclerView.Adapter<RecyclerView.ViewHolder>(), SkillGroupViewHolder.ClickListener {
 
     private val VIEW_TYPE_METRIC = 0;
     private val VIEW_TYPE_GROUP = 1;
     private lateinit var skillAdapterSnapHelper: SnapHelper
+
+    private val clickListener: SkillGroupViewHolder.ClickListener = this
 
     @NonNull
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
@@ -87,7 +88,15 @@ class SkillMetricsAdapter(val context: Context, val metrics: SkillsBasedOnMetric
         } else {
             val itemView = LayoutInflater.from(parent.context)
                     .inflate(R.layout.item_skill_group_list, parent, false)
-            return SkillGroupViewHolder(itemView)
+            return SkillGroupViewHolder(itemView, metrics.metricsList.size, clickListener)
         }
+    }
+
+    override fun onItemClicked(position: Int) {
+        showGroupWiseSkillsFragment(metrics.groups[position])
+    }
+
+    private fun showGroupWiseSkillsFragment(group: String) {
+        skillCallback.loadGroupWiseSkillsFragment(group)
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/viewholders/SkillGroupViewHolder.java
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/viewholders/SkillGroupViewHolder.java
@@ -14,7 +14,7 @@ import butterknife.ButterKnife;
 /**
  * Created by arundhati24 on 12/07/2018.
  */
-public class SkillGroupViewHolder extends RecyclerView.ViewHolder {
+public class SkillGroupViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener {
 
     @BindView(R.id.group_parent)
     public LinearLayout groupParent;
@@ -23,8 +23,25 @@ public class SkillGroupViewHolder extends RecyclerView.ViewHolder {
     @BindView(R.id.ic_arrow)
     public ImageView arrowIcon;
 
-    public SkillGroupViewHolder(View itemView) {
+    private ClickListener listener;
+    private int adapterOffset;
+
+    public SkillGroupViewHolder(View itemView, int adapterOffset, ClickListener clickListener) {
         super(itemView);
         ButterKnife.bind(this, itemView);
+        this.listener = clickListener;
+        itemView.setOnClickListener(this);
+        this.adapterOffset = adapterOffset;
+    }
+
+    @Override
+    public void onClick(View view) {
+        if (listener != null) {
+            listener.onItemClicked(getAdapterPosition() - adapterOffset);
+        }
+    }
+
+    public interface ClickListener {
+        void onItemClicked(int position);
     }
 }

--- a/app/src/main/res/layout/fragment_group_wise_skill_listing.xml
+++ b/app/src/main/res/layout/fragment_group_wise_skill_listing.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<android.support.v4.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/swipeRefreshLayout"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    tools:context="org.fossasia.susi.ai.skills.groupwiseskills.GroupWiseSkillsFragment">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/default_bg">
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/groupWiseSkills"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <ProgressBar
+            android:id="@+id/progressSkillWait"
+            android:layout_width="@dimen/progress_bar_size"
+            android:layout_height="@dimen/progress_bar_size"
+            android:layout_gravity="center" />
+
+        <TextView
+            android:id="@+id/errorSkillFetch"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:gravity="center_horizontal"
+            android:padding="@dimen/padding_very_large"
+            android:text="@string/error_skill_listing"
+            android:textColor="@color/colorPrimary"
+            android:textSize="@dimen/text_size_large"
+            android:visibility="gone" />
+    </FrameLayout>
+</android.support.v4.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/item_group_wise_skill.xml
+++ b/app/src/main/res/layout/item_group_wise_skill.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/margin_very_small">
+
+    <android.support.v7.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:foreground="?attr/selectableItemBackground"
+        app:cardBackgroundColor="@color/susi_message_bg">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/md_white_1000"
+            android:orientation="horizontal">
+
+            <ImageView
+                android:id="@+id/skill_image"
+                android:layout_width="@dimen/skill_image_size"
+                android:layout_height="@dimen/skill_image_size"
+                android:layout_gravity="center"
+                android:adjustViewBounds="true"
+                android:background="@color/md_white_1000"
+                android:padding="@dimen/padding_large"
+                android:scaleType="centerInside"
+                app:srcCompat="@drawable/ic_user"
+                tools:ignore="ContentDescription" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/md_white_1000"
+                android:orientation="vertical"
+                android:paddingBottom="@dimen/cmv_padding"
+                android:paddingEnd="@dimen/cmv_padding"
+                android:paddingRight="@dimen/cmv_padding"
+                android:paddingTop="@dimen/cmv_padding">
+
+                <TextView
+                    android:id="@+id/skill_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/md_white_1000"
+                    android:paddingLeft="@dimen/cmv_padding"
+                    android:paddingStart="@dimen/cmv_padding"
+                    android:text="@string/skill_name"
+                    android:textColor="@color/colorPrimary"
+                    android:textSize="@dimen/skill_title"
+                    android:textStyle="bold" />
+
+                <TextView
+                    android:id="@+id/skill_author_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/md_white_1000"
+                    android:gravity="center_vertical"
+                    android:paddingLeft="@dimen/cmv_padding"
+                    android:paddingStart="@dimen/cmv_padding"
+                    android:text="@string/author_name"
+                    android:textColor="@color/md_grey_800"
+                    android:textSize="@dimen/skill_description" />
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:background="@color/md_white_1000"
+                    android:orientation="horizontal">
+
+                    <RatingBar
+                        android:id="@+id/skill_rating"
+                        style="?android:attr/ratingBarStyleSmall"
+                        android:layout_width="@dimen/rating_bar_layout_width"
+                        android:layout_height="wrap_content"
+                        android:background="@color/md_white_1000"
+                        android:numStars="5"
+                        android:paddingBottom="@dimen/cmv_padding"
+                        android:paddingEnd="@dimen/cmv_padding"
+                        android:paddingLeft="@dimen/cmv_padding"
+                        android:paddingRight="@dimen/cmv_padding"
+                        android:paddingStart="@dimen/cmv_padding"
+                        android:theme="@style/RatingBar" />
+
+                    <TextView
+                        android:id="@+id/skill_total_ratings"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="@color/md_white_1000"
+                        android:paddingBottom="@dimen/cmv_padding"
+                        android:text="@string/digit_zero"
+                        android:textColor="@color/colorPrimary" />
+                </LinearLayout>
+
+                <TextView
+                    android:id="@+id/skill_example"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:background="@color/md_white_1000"
+                    android:paddingLeft="@dimen/cmv_padding"
+                    android:paddingStart="@dimen/cmv_padding"
+                    android:text="@string/examples"
+                    android:textColor="@color/md_grey_800"
+                    android:textSize="@dimen/skill_example"
+                    android:typeface="monospace" />
+            </LinearLayout>
+        </LinearLayout>
+
+    </android.support.v7.widget.CardView>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -286,7 +286,7 @@
     <string name="susi_skill_cms_desc">SUSI is having many skills. You can look at the collection of skills at <a href="http://www.skills.susi.ai"><font color='#4184f3'>skills.susi.ai</font></a>. SUSI Skill development is easy and fun. You can edit existing skills or even create your own.</string>
 
     <!-- Intro Strings -->
-    <string name="author_name">Author: Author name</string>
+    <string name="author_name">Author name</string>
 
     <string name="content_type_dynamic">Content Type: Dynamic</string>
     <string name="content_type_static">Content Type: Static</string>


### PR DESCRIPTION
Fixes #1539  [Parent issue #1467]

Changes: The skills belonging to a particular group are loaded in a new fragment when the user taps that group.

Screenshots for the change: 

<img width="336" alt="screen shot 2018-07-17 at 2 43 45 pm" src="https://user-images.githubusercontent.com/30979369/42807992-dc358372-89cf-11e8-952a-c30a5267787c.png">

