### PR TITLE
Load skill details when a skill card in GroupWiseSkillsFragment is clicked (Fixed #1549)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/GroupWiseSkillsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/GroupWiseSkillsFragment.kt
@@ -1,5 +1,6 @@
 package org.fossasia.susi.ai.skills.groupwiseskills
 
+import android.content.Context
 import android.support.v4.app.Fragment
 import android.os.Bundle
 import android.support.annotation.NonNull
@@ -14,9 +15,11 @@ import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.dataclasses.GroupWiseSkills
 import org.fossasia.susi.ai.helper.SimpleDividerItemDecoration
 import org.fossasia.susi.ai.helper.StartSnapHelper
+import org.fossasia.susi.ai.skills.SkillFragmentCallback
 import org.fossasia.susi.ai.skills.groupwiseskills.adapters.recycleradapters.SkillsListAdapter
 import org.fossasia.susi.ai.skills.groupwiseskills.contract.IGroupWiseSkillsPresenter
 import org.fossasia.susi.ai.skills.groupwiseskills.contract.IGroupWiseSkillsView
+import timber.log.Timber
 
 /**
  *
@@ -27,6 +30,7 @@ class GroupWiseSkillsFragment : Fragment(), IGroupWiseSkillsView, SwipeRefreshLa
     private lateinit var groupWiseSkillsPresenter: IGroupWiseSkillsPresenter
     private var skills = GroupWiseSkills("", ArrayList())
     private lateinit var skillsAdapter: SkillsListAdapter
+    private lateinit var skillCallback: SkillFragmentCallback
 
     companion object {
         const val SKILL_GROUP = "group"
@@ -63,7 +67,7 @@ class GroupWiseSkillsFragment : Fragment(), IGroupWiseSkillsView, SwipeRefreshLa
         val mLayoutManager = LinearLayoutManager(activity)
         mLayoutManager.orientation = LinearLayoutManager.VERTICAL
         groupWiseSkills.layoutManager = mLayoutManager
-        skillsAdapter = SkillsListAdapter(requireContext(), skills)
+        skillsAdapter = SkillsListAdapter(requireContext(), skills, skillCallback)
         groupWiseSkills.adapter = skillsAdapter
         groupWiseSkills.onFlingListener = null
         skillAdapterSnapHelper.attachToRecyclerView(groupWiseSkills)
@@ -99,6 +103,15 @@ class GroupWiseSkillsFragment : Fragment(), IGroupWiseSkillsView, SwipeRefreshLa
         this.skills.skillsList.addAll(skills.skillsList)
         groupWiseSkills.addItemDecoration(SimpleDividerItemDecoration(context, this.skills.skillsList.size))
         skillsAdapter.notifyDataSetChanged()
+    }
+
+    override fun onAttach(context: Context) {
+        super.onAttach(context);
+        if (context is SkillFragmentCallback) {
+            skillCallback = context
+        } else {
+            Timber.e("context is not SkillFragmentCallback")
+        }
     }
 
     override fun onRefresh() {

--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/recycleradapters/SkillsListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/recycleradapters/SkillsListAdapter.kt
@@ -8,15 +8,19 @@ import android.view.ViewGroup
 import com.squareup.picasso.Picasso
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.dataclasses.GroupWiseSkills
+import org.fossasia.susi.ai.rest.responses.susi.SkillData
+import org.fossasia.susi.ai.skills.SkillFragmentCallback
 import org.fossasia.susi.ai.skills.groupwiseskills.adapters.viewholders.SkillViewHolder
 
 /**
  *
  * Created by arundhati24 on 16/07/2018.
  */
-class SkillsListAdapter(val context: Context, private val skillDetails: GroupWiseSkills) : RecyclerView.Adapter<SkillViewHolder>() {
+class SkillsListAdapter(val context: Context, private val skillDetails: GroupWiseSkills, val skillCallback: SkillFragmentCallback) :
+        RecyclerView.Adapter<SkillViewHolder>(), SkillViewHolder.ClickListener {
 
     private val imageLink = "https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/general/"
+    private val clickListener: SkillViewHolder.ClickListener = this
 
     @NonNull
     override fun onBindViewHolder(holder: SkillViewHolder, position: Int) {
@@ -64,10 +68,26 @@ class SkillsListAdapter(val context: Context, private val skillDetails: GroupWis
         return skillDetails.skillsList.size
     }
 
+    override fun onItemClicked(position: Int) {
+        var skillTag: String? = ""
+        if (skillDetails.skillsList[position].skillTag != null) {
+            skillTag = skillDetails.skillsList.toTypedArray().get(position).skillTag
+        } else {
+            skillTag = ""
+        }
+        val skillData = skillDetails.skillsList.get(position)
+        val skillGroup = skillDetails.skillsList.get(position).group.replace(" ", "%20")
+        showSkillDetailFragment(skillData, skillGroup, skillTag)
+    }
+
+    private fun showSkillDetailFragment(skillData: SkillData, skillGroup: String, skillTag: String) {
+        skillCallback.loadDetailFragment(skillData, skillGroup, skillTag)
+    }
+
     @NonNull
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SkillViewHolder {
         val itemView = LayoutInflater.from(parent.context)
                 .inflate(R.layout.item_group_wise_skill, parent, false)
-        return SkillViewHolder(itemView)
+        return SkillViewHolder(itemView, clickListener)
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/viewholders/SkillViewHolder.java
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/viewholders/SkillViewHolder.java
@@ -14,7 +14,7 @@ import butterknife.ButterKnife;
 /**
  * Created by arundhati24 on 16/07/2018.
  */
-public class SkillViewHolder extends RecyclerView.ViewHolder {
+public class SkillViewHolder extends RecyclerView.ViewHolder implements View.OnClickListener{
 
     @BindView(R.id.skill_image)
     public ImageView skillImage;
@@ -29,8 +29,23 @@ public class SkillViewHolder extends RecyclerView.ViewHolder {
     @BindView(R.id.skill_total_ratings)
     public TextView skillTotalRatings;
 
-    public SkillViewHolder(View itemView) {
+    private ClickListener listener;
+
+    public SkillViewHolder(View itemView, ClickListener clickListener) {
         super(itemView);
         ButterKnife.bind(this, itemView);
+        this.listener = clickListener;
+        itemView.setOnClickListener(this);
+    }
+
+    @Override
+    public void onClick(View view) {
+        if (listener != null) {
+            listener.onItemClicked(getAdapterPosition());
+        }
+    }
+
+    public interface ClickListener {
+        void onItemClicked(int position);
     }
 }


### PR DESCRIPTION
Fixes #1549 [Parent issue #1467]

Changes: Skill details shown when a skill card is clicked.