### PR TITLE
Fixed problem loading skills when the user has not set a language explicitly (Fixed #1485)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginPresenter.kt
@@ -157,7 +157,11 @@ class LoginPresenter(loginActivity: LoginActivity) : ILoginPresenter, ILoginMode
                 utilModel.putBooleanPref(Constant.ENTER_SEND, settings.enterSend)
                 utilModel.putBooleanPref(Constant.SPEECH_ALWAYS, settings.speechAlways)
                 utilModel.putBooleanPref(Constant.SPEECH_OUTPUT, settings.speechOutput)
-                utilModel.setLanguage(settings.language)
+                if (settings.language == "default") {
+                    utilModel.setLanguage("en")
+                } else {
+                    utilModel.setLanguage(settings.language)
+                }
             }
 
             loginView?.onLoginSuccess(message)


### PR DESCRIPTION
Fixes #1485 

Changes: Now the skills are loaded even when the user logs in for the first time.