### PR TITLE
Use appropriate action bar titles (Fixed #1567)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/GroupWiseSkillsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/GroupWiseSkillsFragment.kt
@@ -53,7 +53,7 @@ class GroupWiseSkillsFragment : Fragment(), IGroupWiseSkillsView, SwipeRefreshLa
 
     @NonNull
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        activity?.title = activity?.getString(R.string.skills_activity)
+        activity?.title = this.skills.group
         groupWiseSkillsPresenter = GroupWiseSkillsPresenter(this)
         groupWiseSkillsPresenter.onAttach(this)
         swipeRefreshLayout.setOnRefreshListener(this)

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -88,8 +88,7 @@ class SkillDetailsFragment : Fragment(), ISkillDetailsView {
 
     @NonNull
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        if (skillData.skillName != null && !skillData.skillName.isEmpty())
-            (activity as SkillsActivity).title = skillData.skillName
+        skillData?.skillName?.let { activity?.title = skillData.skillName }
         setupUI()
         super.onViewCreated(view, savedInstanceState)
     }


### PR DESCRIPTION
Fixes #1567 

Changes: The title bar now shows the correct titles for the Skills Listing Fragment, Group Wise Skills Listing Fragment and Skill Details Fragment.

**Screenshots**

![screenshot_2018-07-21-09-45-18-028_ai susi](https://user-images.githubusercontent.com/30979369/43032029-32e5951a-8ccb-11e8-8c98-04055f498cf4.png)

![screenshot_2018-07-21-09-45-29-430_ai susi](https://user-images.githubusercontent.com/30979369/43032034-41527f82-8ccb-11e8-9e1d-ae0cf2bd4139.png)

![screenshot_2018-07-21-09-45-20-115_ai susi](https://user-images.githubusercontent.com/30979369/43032042-5553b712-8ccb-11e8-837a-4ab9c7f0e7af.png)

