### PR TITLE
fix: Swipe to type on the chat activity keyboard

### DIFF
--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -86,7 +86,7 @@
                             android:background="@android:color/transparent"
                             android:cursorVisible="true"
                             android:hint="@string/send_msg_hint"
-                            android:inputType="textNoSuggestions|textVisiblePassword"
+                            android:inputType="text"
                             android:scrollbars="vertical"
                             android:textCursorDrawable="@null"
                             android:theme="@style/sendMessageEditTextTheme" />


### PR DESCRIPTION
Fixes #1578 
Changes: Swipe to type on the keyboard is now possible.

