### PR TITLE
Add newest and top gaming skills to skills listing page (Fixed #1587)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/rest/responses/susi/Metrics.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/rest/responses/susi/Metrics.kt
@@ -1,5 +1,8 @@
 package org.fossasia.susi.ai.rest.responses.susi
 
+import com.google.gson.annotations.Expose
+import com.google.gson.annotations.SerializedName
+
 /**
  *
  * Created by arundhati24 on 12/07/2018
@@ -9,4 +12,9 @@ class Metrics {
     val usage: List<SkillData> = ArrayList()
     val rating: List<SkillData> = ArrayList()
     val latest: List<SkillData> = ArrayList()
+    val newest: List<SkillData> = ArrayList()
+
+    @SerializedName("Games, Trivia and Accessories")
+    @Expose
+    val topGames: List<SkillData> = ArrayList()
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
@@ -114,6 +114,17 @@ class SkillListingPresenter(val skillListingFragment: SkillListingFragment) : IS
                     }
                 }
 
+                if (metricsData?.newest != null) {
+                    val size = metricsData?.newest?.size
+                    if (size is Int) {
+                        if (size > 0) {
+                            metrics.metricsGroupTitles.add(utilModel.getString(R.string.metric_newest))
+                            metrics.metricsList.add(metricsData?.newest)
+                            skillListingView?.updateAdapter(metrics)
+                        }
+                    }
+                }
+
                 if (metricsData?.latest != null) {
                     if (metricsData?.latest?.size as Int > 0) {
                         metrics.metricsGroupTitles.add(utilModel.getString(R.string.metric_latest))
@@ -127,6 +138,17 @@ class SkillListingPresenter(val skillListingFragment: SkillListingFragment) : IS
                         metrics.metricsGroupTitles.add(utilModel.getString(R.string.metric_feedback))
                         metrics.metricsList.add(metricsData?.feedback)
                         skillListingView?.updateAdapter(metrics)
+                    }
+                }
+
+                if (metricsData?.topGames != null) {
+                    val size = metricsData?.feedback?.size
+                    if (size is Int) {
+                        if (size > 0) {
+                            metrics.metricsGroupTitles.add(utilModel.getString(R.string.metrics_top_games))
+                            metrics.metricsList.add(metricsData?.topGames)
+                            skillListingView?.updateAdapter(metrics)
+                        }
                     }
                 }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -395,5 +395,7 @@
     <string name="metric_usage">\"SUSI, what are your most used skills?\"</string>
     <string name="metric_latest">\"SUSI, what are the recently updated skills?\"</string>
     <string name="metric_feedback">\"SUSI, what are the skills with most feedback?\"</string>
+    <string name="metric_newest">\"SUSI, what are the newest skills?\"</string>
+    <string name="metrics_top_games">\"SUSI, what are your top games?\"</string>
     <string name="message_no_skills_found">No skills found.</string>
 </resources>


### PR DESCRIPTION
Fixes #1587 

Changes: Now, newest and top gaming skills are displayed in the skills listing page.

Screenshots for the change: 

![newest](https://user-images.githubusercontent.com/30979369/43360038-ddf46fa2-92cb-11e8-82c9-8d9206eb4ac0.png)

![topgames](https://user-images.githubusercontent.com/30979369/43360110-46341d6e-92cd-11e8-9906-262d4f76d8cf.png)
