### PR TITLE
Use circular image view for skill image in group wise skill cards (Fixed #1633)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/recycleradapters/SkillsListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/recycleradapters/SkillsListAdapter.kt
@@ -8,6 +8,7 @@ import android.view.ViewGroup
 import com.squareup.picasso.Picasso
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.dataclasses.GroupWiseSkills
+import org.fossasia.susi.ai.helper.CircleTransform
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
 import org.fossasia.susi.ai.skills.SkillFragmentCallback
 import org.fossasia.susi.ai.skills.groupwiseskills.adapters.viewholders.SkillViewHolder
@@ -52,6 +53,7 @@ class SkillsListAdapter(val context: Context, private val skillDetails: GroupWis
                         .append(imageUrl).toString())
                         .fit().centerCrop()
                         .error(R.drawable.ic_susi)
+                        .transform(CircleTransform())
                         .into(holder.skillImage)
             }
 


### PR DESCRIPTION
Fixes #1633 

Screenshots for the change: 

![circularskillimg](https://user-images.githubusercontent.com/30979369/43569062-0adf9c90-9654-11e8-8572-22d81dc7c0b7.png)

