### PR TITLE
Move About option at the bottom in the menu (Fixed #1644)

### DIFF
--- a/app/src/main/res/menu/skills_activity_menu.xml
+++ b/app/src/main/res/menu/skills_activity_menu.xml
@@ -2,13 +2,13 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
-        android:id="@+id/menu_about"
-        android:icon="@drawable/ic_about"
-        android:title="@string/menu_item_about" />
-    <item
         android:id="@+id/menu_settings"
         android:icon="@drawable/ic_settings_24dp"
         android:title="@string/menu_item_settings" />
+    <item
+        android:id="@+id/menu_about"
+        android:icon="@drawable/ic_about"
+        android:title="@string/menu_item_about" />
     <item
         android:id="@+id/action_search"
         android:icon="@drawable/ic_open_search"


### PR DESCRIPTION
Fixes #1644 

Changes: Now About option is shown at the bottom of the menu.