### PR TITLE
Add horizontal recyclerview to display staff picks on skills listing page (Fixed #1653)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/rest/responses/susi/Metrics.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/rest/responses/susi/Metrics.kt
@@ -7,6 +7,7 @@ import com.google.gson.annotations.SerializedName
  * Created by arundhati24 on 12/07/2018
  */
 data class Metrics(
+        val staffPicks: List<SkillData> = ArrayList(),
         val feedback: List<SkillData> = ArrayList(),
         val usage: List<SkillData> = ArrayList(),
         val rating: List<SkillData> = ArrayList(),

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
@@ -98,6 +98,15 @@ class SkillListingPresenter(val skillListingFragment: SkillListingFragment) : IS
             if (metricsData != null) {
                 metrics.metricsList.clear()
                 metrics.metricsGroupTitles.clear()
+                if (metricsData?.staffPicks != null && metricsData?.staffPicks?.size != null) {
+                    //TODO : Make this comparison null safe
+                    if (metricsData?.staffPicks?.size!! > 0) {
+                        metrics.metricsGroupTitles.add(utilModel.getString(R.string.metric_staff_picks))
+                        metrics.metricsList.add(metricsData?.staffPicks)
+                        skillListingView?.updateAdapter(metrics)
+                    }
+                }
+
                 if (metricsData?.rating != null) {
                     if (metricsData?.rating?.size as Int > 0) {
                         metrics.metricsGroupTitles.add(utilModel.getString(R.string.metric_rating))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -391,6 +391,7 @@
 
     <!-- Metrics -->
 
+    <string name="metric_staff_picks">Staff Picks</string>
     <string name="metric_rating">\"SUSI, What are your highest rated skills?\"</string>
     <string name="metric_usage">\"SUSI, what are your most used skills?\"</string>
     <string name="metric_latest">\"SUSI, what are the recently updated skills?\"</string>


### PR DESCRIPTION
Fixes #1653 

Screenshots for the change: 

![staffpicks](https://user-images.githubusercontent.com/30979369/43880518-68a3148e-9bc6-11e8-8533-5dec749f89d7.png)
