### PR TITLE
Display skills images on skills card in a circular image view (Fixed #1655)

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/helper/Utils.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/Utils.kt
@@ -18,6 +18,7 @@ object Utils {
         Picasso.with(imageView.context)
                 .load(getImageLink(skillData))
                 .error(R.drawable.ic_susi)
+                .transform(CircleTransform())
                 .fit()
                 .centerCrop()
                 .into(imageView)


### PR DESCRIPTION
Fixes #1655 

Screenshots for the change: 

Before: 
![noncircle](https://user-images.githubusercontent.com/30979369/43880986-481dddd2-9bc8-11e8-8b2d-3135121b02e7.png)

After:
![circle](https://user-images.githubusercontent.com/30979369/43880995-4fc584fe-9bc8-11e8-8f18-91a3b98486b8.png)

