### PR TITLE
fix: make examples sections invisible when example list is empty

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -188,11 +188,14 @@ class SkillDetailsFragment : Fragment(), ISkillDetailsView {
     }
 
     private fun setExamples() {
-        if (skillData.examples != null) {
+        if (skillData.examples != null && skillData.examples.isNotEmpty()) {
             skillDetailExamples.setHasFixedSize(true)
             val mLayoutManager = LinearLayoutManager(activity, LinearLayoutManager.HORIZONTAL, false)
             skillDetailExamples.layoutManager = mLayoutManager
             skillDetailExamples.adapter = SkillExamplesAdapter(requireContext(), skillData.examples)
+        } else {
+            skillDetailExample.visibility = View.GONE
+            skillDetailExamples.visibility = View.GONE
         }
     }
 

--- a/app/src/main/res/layout/fragment_skill_details.xml
+++ b/app/src/main/res/layout/fragment_skill_details.xml
@@ -114,6 +114,7 @@
                 android:layout_marginTop="@dimen/margin_large"
                 android:background="@color/md_white_1000"
                 android:text="@string/examples"
+                android:id="@+id/skillDetailExample"
                 android:textColor="@color/md_grey_700"
                 android:textSize="@dimen/text_size_large"
                 app:fontFamily="sans-serif" />


### PR DESCRIPTION
Fixes #1564 : Made examples sections invisible when example list is empty

Changes: Set the visibility to gone

Edit:

Screenshots:

![screenshot-1534774596095](https://user-images.githubusercontent.com/20026440/44345837-059b5500-a4b2-11e8-9b4d-1c61b42eaec1.jpg)

@arundhati24 @batbrain7 Check this!