### PR TITLE
chore: Remove translations for strings with translatable attribute set to false

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -15,7 +15,6 @@
     <string name="search">Suche</string>
     <string name="select_background">Hintergrund auswählen</string>
     <string name="background_no_wall">no_wall</string>
-    <string name="enter_send" translatable="false">Enter_send</string>
     <string name="id">id</string>
     <string name="no_internet_connection"> Keine Internetverbindung!!</string>
     <string name="updated_successfully">Erfolgreich aktualisiert!</string>
@@ -56,11 +55,6 @@
     <string name="settings_enterPreference_label">Geben Sie als Send ein</string>
     <string name="setting_mic_input">Mic Eingang</string>
     <string name="setting_hotword_detection">Hotword-Erkennung (Beta)</string>
-    <string name="setting_mic_key" translatable="false">mic_input</string>
-    <string name="setting_hotword_key" translatable="false">hotword_detection</string>
-    <string name="settings_enterPreference_key" translatable="false">enter_send</string>
-    <string name="settings_speechPreference_key" translatable="false">speech_output</string>
-    <string name="settings_speechAlways_key" translatable="false">speech_always</string>
     <string name="hello_world">Hallo Welt!</string>
     <string name="speech_prompt">Sag etwas&#8230;</string>
     <string name="speech_not_supported">Es tut uns leid! Ihr Gerät unterstützt keine Spracheingabe</string>
@@ -105,7 +99,6 @@
     <string name="activity_login_forgot_pass">Passwort vergessen?</string>
     <string name="activity_login_sign_up">Melden Sie sich für SUSI an</string>
     <string name="activity_login_skip">Überspringen</string>
-    <string name="activity_login_imageview_description" translatable="false">SUSI Logo</string>
     <string name="unknown_answer">Ich weiß es nicht.</string>
     <string name="settings_mic">Mic-Einstellungen</string>
     <string name="settings_speech">Spracheinstellungen</string>
@@ -150,6 +143,5 @@
     <!--Share App strings-->
     <string name="promo_msg_template">Hey, versuch es! -%s. Du wirst es lieben!</string>
     <string name="error_msg_retry">Bitte wiederholen Sie erneut</string>
-    <string name="app_share_url" translatable="false">https://play.google.com/store/apps/details?id=%s</string>
     <string name="logout">Ausloggen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -14,7 +14,6 @@
     <string name="search">Buscar</string>
     <string name="select_background">Seleccionar fondo</string>
     <string name="background_no_wall">no_wall</string>
-    <string name="enter_send" translatable="false">Enter_send</string>
     <string name="id">id</string>
     <string name="no_internet_connection">Conexión a Internet No Disponible!!</string>
     <string name="updated_successfully">actualizado exitosamente!</string>
@@ -55,11 +54,6 @@ Enlace de confirmación para activar su cuenta e iniciar sesión en susi.</strin
     <string name="settings_enterPreference_label">Introducir como Enviar</string>
     <string name="setting_mic_input">Entrada de micrófono</string>
     <string name="setting_hotword_detection">Detección de Hotword (Beta)</string>
-    <string name="setting_mic_key" translatable="false">mic_input</string>
-    <string name="setting_hotword_key" translatable="false">hotword_detection</string>
-    <string name="settings_enterPreference_key" translatable="false">enter_send</string>
-    <string name="settings_speechPreference_key" translatable="false">speech_output</string>
-    <string name="settings_speechAlways_key" translatable="false">speech_always</string>
     <string name="hello_world">Hola Mundo!</string>
     <string name="speech_prompt">Di algo&#8230;</string>
     <string name="speech_not_supported">¡Lo siento! Su dispositivo no admite la entrada de voz</string>
@@ -104,7 +98,6 @@ Enlace de confirmación para activar su cuenta e iniciar sesión en susi.</strin
     <string name="activity_login_forgot_pass">Olvidó Contraseña?</string>
     <string name="activity_login_sign_up">Inscríbase en SUSI</string>
     <string name="activity_login_skip">Omitir</string>
-    <string name="activity_login_imageview_description" translatable="false">Logotipo de SUSI</string>
     <string name="unknown_answer">No lo sé.</string>
     <string name="settings_mic">Ajustes del Mic</string>
     <string name="settings_speech">Configuración de Voz</string>
@@ -149,6 +142,5 @@ Enlace de confirmación para activar su cuenta e iniciar sesión en susi.</strin
     <!--Share App strings-->
     <string name="promo_msg_template">Oye, prueba esto! - %s . Lo amarás!</string>
     <string name="error_msg_retry">Por favor, vuelva a intentarlo</string>
-    <string name="app_share_url" translatable="false">https://play.google.com/store/apps/details?id=%s</string>
     <string name="logout">Logout</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -15,7 +15,6 @@
     <string name="search">खोज</string>
     <string name="select_background">पृष्ठभूमि का चयन करें</string>
     <string name="background_no_wall">नहीं पृष्ठभूमि</string>
-    <string name="enter_send" translatable="false">भेजें दर्ज करें</string>
     <string name="id">आईडी</string>
     <string name="no_internet_connection">इंटरनेट कनेक्शन उपलब्ध नहीं है !!</string>
     <string name="updated_successfully">अद्यतन सफलतापूर्ण हो गया!</string>
@@ -54,11 +53,6 @@
     <string name="settings_enterPreference_label">भेजें के रूप में दर्ज करें</string>
     <string name="setting_mic_input">माइक्र इनपुट</string>
     <string name="setting_hotword_detection">हॉटवर्ड डिटेक्शन (बीटा)</string>
-    <string name="setting_mic_key" translatable="false">माइक्र इनपुट</string>
-    <string name="setting_hotword_key" translatable="false">हॉटवर्ड डिटेक्शन</string>
-    <string name="settings_enterPreference_key" translatable="false">भेजें के रूप में दर्ज करें</string>
-    <string name="settings_speechPreference_key" translatable="false">भाषण आउटपुट</string>
-    <string name="settings_speechAlways_key" translatable="false">भाषण आउटपुट हमेशा</string>
     <string name="hello_world">नमस्ते दुनिया!</string>
     <string name="speech_prompt">कुछ कहो # 8230;</string>
     <string name="speech_not_supported">माफ़ कीजिये! आपका उपकरण भाषण इनपुट का समर्थन नहीं करता है</string>
@@ -105,7 +99,6 @@
     <string name="activity_login_forgot_pass">पासवर्ड भूल गए?</string>
     <string name="activity_login_sign_up">सुसी के लिए साइन अप करें</string>
     <string name="activity_login_skip">छोड़ें</string>
-    <string name="activity_login_imageview_description" translatable="false">सुसी प्रतीक चिन्ह</string>
     <string name="unknown_answer">मुझे नहीं पता।</string>
     <string name="settings_mic">माइक सेटिंग्स</string>
     <string name="settings_speech">भाषण सेटिंग</string>
@@ -153,7 +146,6 @@
     <!--Share App strings-->
     <string name="promo_msg_template">हे, कोशिश करो! -% s आप इसे प्यार करेंगे!</string>
     <string name="error_msg_retry">कृपया फिर से प्रयास करें</string>
-    <string name="app_share_url" translatable="false">https://play.google.com/store/apps/details?id=%s</string>
     <string name="logout">लोग आउट</string>
     <string name="skills">कौशल</string>
     <string name="skill_title">कौशल शीर्षक</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -14,7 +14,6 @@
     <string name="search">cerca</string>
     <string name="select_background">Seleziona sfondo</string>
     <string name="background_no_wall">no_wall</string>
-    <string name="enter_send" translatable="false">Enter_send</string>
     <string name="id">id</string>
     <string name="no_internet_connection">Nessuna Connessione Internet Disponibile!!</string>
     <string name="updated_successfully"> aggiornato con successo!</string>
@@ -55,11 +54,6 @@
     <string name="settings_enterPreference_label">Inserisci Come Invia</string>
     <string name="setting_mic_input">Ingresso microfono</string>
     <string name="setting_hotword_detection">Rilevamento (Beta) di Hotword</string>
-    <string name="setting_mic_key" translatable="false">mic_input</string>
-    <string name="setting_hotword_key" translatable="false">hotword_detection</string>
-    <string name="settings_enterPreference_key" translatable="false">enter_send</string>
-    <string name="settings_speechPreference_key" translatable="false">speech_output</string>
-    <string name="settings_speechAlways_key" translatable="false">speech_always</string>
     <string name="hello_world">Hello world!</string>
     <string name="speech_prompt">dí qualcosa &#8230;</string>
     <string name="speech_not_supported">mi dispiace! Il tuo dispositivo non supporta l\'input vocale</string>
@@ -104,7 +98,6 @@
     <string name="activity_login_forgot_pass">Ha dimenticato la password?</string>
     <string name="activity_login_sign_up">Registrati per SUSI</string>
     <string name="activity_login_skip">Saltare</string>
-    <string name="activity_login_imageview_description" translatable="false">SUSI Logo</string>
     <string name="unknown_answer">Non lo so.</string>
     <string name="settings_mic">Impostazioni del Mic</string>
     <string name="settings_speech">Impostazioni vocali</string>
@@ -149,6 +142,5 @@
     <!--Share App strings-->
     <string name="promo_msg_template">Hey, prova questo! - %s . Lo amerai!</string>
     <string name="error_msg_retry">Riprova nuovamente</string>
-    <string name="app_share_url" translatable="false">https://play.google.com/store/apps/details?id=%s</string>
     <string name="logout">Logout</string>
 </resources>


### PR DESCRIPTION
Fixes #1686 

Changes: Removed translations for strings for which translatable attribute has been set to false, from other string localization files.