### PR TITLE
fix: Display the entire email string for the logged in user

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/feedback/adapters/recycleradapters/AllReviewsAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/feedback/adapters/recycleradapters/AllReviewsAdapter.kt
@@ -7,6 +7,8 @@ import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import org.fossasia.susi.ai.R
+import org.fossasia.susi.ai.helper.Constant
+import org.fossasia.susi.ai.helper.PrefManager
 import org.fossasia.susi.ai.helper.Utils
 import org.fossasia.susi.ai.rest.responses.susi.Feedback
 import org.fossasia.susi.ai.skills.feedback.adapters.viewholders.AllReviewsViewHolder
@@ -40,7 +42,15 @@ class AllReviewsAdapter(val context: Context, val feedbackList: List<Feedback>?)
                 if (feedbackList[position].email != null &&
                         !TextUtils.isEmpty(feedbackList[position].email)) {
                     Utils.setAvatar(context, feedbackList.get(position).email, holder.avatar)
-                    Utils.truncateEmailAtEnd(feedbackList.get(position).email)?.let { holder.feedbackEmail?.text = it }
+                    if (PrefManager.getToken() != null) {
+                        if (!feedbackList.get(position).email.equals(PrefManager.getStringSet(Constant.SAVED_EMAIL).iterator().next().toString(), true)) {
+                            Utils.truncateEmailAtEnd(feedbackList.get(position).email)?.let { holder.feedbackEmail?.text = it }
+                        } else {
+                            holder.feedbackEmail.text = feedbackList.get(position).email
+                        }
+                    } else {
+                        Utils.truncateEmailAtEnd(feedbackList.get(position).email)?.let { holder.feedbackEmail?.text = it }
+                    }
                 }
                 if (feedbackList[position].timestamp != null &&
                         !TextUtils.isEmpty(feedbackList[position].timestamp)) {

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
@@ -10,6 +10,8 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import org.fossasia.susi.ai.R
+import org.fossasia.susi.ai.helper.Constant
+import org.fossasia.susi.ai.helper.PrefManager
 import org.fossasia.susi.ai.helper.Utils
 import org.fossasia.susi.ai.rest.responses.susi.GetSkillFeedbackResponse
 import org.fossasia.susi.ai.skills.feedback.FeedbackActivity
@@ -52,7 +54,15 @@ class FeedbackAdapter(val context: Context, val feedbackResponse: GetSkillFeedba
                         if (feedbackResponse.feedbackList[position].email != null &&
                                 !TextUtils.isEmpty(feedbackResponse.feedbackList[position].email)) {
                             Utils.setAvatar(context, feedbackResponse.feedbackList.get(position).email, holder.avatar)
-                            Utils.truncateEmailAtEnd(feedbackResponse.feedbackList.get(position).email)?.let { holder.feedbackEmail?.text = it }
+                            if (PrefManager.getToken() != null) {
+                                if (!feedbackResponse.feedbackList.get(position).email.equals(PrefManager.getStringSet(Constant.SAVED_EMAIL).iterator().next().toString(), true)) {
+                                    Utils.truncateEmailAtEnd(feedbackResponse.feedbackList.get(position).email)?.let { holder.feedbackEmail?.text = it }
+                                } else {
+                                    holder.feedbackEmail.text = feedbackResponse.feedbackList.get(position).email
+                                }
+                            } else {
+                                Utils.truncateEmailAtEnd(feedbackResponse.feedbackList.get(position).email)?.let { holder.feedbackEmail?.text = it }
+                            }
                         }
                         if (feedbackResponse.feedbackList[position].timestamp != null &&
                                 !TextUtils.isEmpty(feedbackResponse.feedbackList[position].timestamp)) {


### PR DESCRIPTION
Fixes #1680

Changes: The email of all the users was anonymized in the feedback section. Now, the
email of the logged in user will not be anonymized.

Screenshots for the change: 

**BEFORE**

![screenshot_2018-09-02-10-28-05-631_ai susi](https://user-images.githubusercontent.com/30979369/44952379-73288780-ae9b-11e8-80ec-41289b964f69.png)

![screenshot_2018-09-02-10-28-11-972_ai susi](https://user-images.githubusercontent.com/30979369/44952380-7a4f9580-ae9b-11e8-80d5-b6f88b835b8e.png)

**AFTER**

![screenshot_2018-09-02-10-18-59-899_ai susi](https://user-images.githubusercontent.com/30979369/44952384-8e939280-ae9b-11e8-942d-da3a21517234.png)

![screenshot_2018-09-02-10-19-04-054_ai susi](https://user-images.githubusercontent.com/30979369/44952385-981cfa80-ae9b-11e8-9285-8a1c094212f3.png)

