### PR TITLE
Fix for login dialog incase of wrong credentials

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginPresenter.kt
@@ -137,8 +137,8 @@ class LoginPresenter(loginActivity: LoginActivity) : ILoginPresenter, ILoginMode
             message = response.body().message.toString()
         } else if (response.code() == 422) {
             loginView?.showProgress(false)
-            loginView?.onLoginError(utilModel.getString(R.string.password_invalid_title),
-                    utilModel.getString(R.string.password_invalid))
+            loginView?.onLoginError(utilModel.getString(R.string.invalid_credentials_title),
+                    utilModel.getString(R.string.invalid_credentials))
         } else {
             loginView?.showProgress(false)
             loginView?.onLoginError("${response.code()} " + utilModel.getString(R.string.error),

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -186,6 +186,8 @@
     <string name="unknown_host_exception">Unknown Host Exception</string>
     <string name="check_email">Check your email!</string>
     <string name="reset_password_text">We just sent you an email with a link to reset \n your password.</string>
+    <string name="invalid_credentials_title">Invalid credentials.</string>
+    <string name="invalid_credentials">Invalid credentials. Please try again</string>
 
     <!-- Settings Activity-->
     <string name="Continue">Continue</string>


### PR DESCRIPTION
Fixex #1694  
@iamareebjamal 
This fix provides a feedback to user incase of wrong credentials such as email, password . Also modified the string.xml files to  suit all the languages. For now the setting tab crashes the app. Would have loved to test the different languages.But i guess it will do if it does in english then fine.

Here is the screenshot in english 
![screenshot_20180912-130207](https://user-images.githubusercontent.com/16350814/45423788-555cde80-b662-11e8-8f8d-722d47050ec1.png)
