### PR TITLE
fix: Use correct color primary to make it consistent with other clients

### DIFF
--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="colorPrimary">#4184f3</color>
-    <color name="colorPrimaryDark">#4184f3</color>
+    <color name="colorPrimary">#4285f4</color>
+    <color name="colorPrimaryDark">#0d5bdd</color>
     <color name="colorAccent">#000000</color>
 
     <!-- google's material design colours from http://www.google.com/design/spec/style/color.html#color-ui-color-palette -->


### PR DESCRIPTION
Fixes #1719 

Changes: Changed the color primary of the app to #4285f4 .