### PR TITLE
feat: Update UI of About Us Fragment

### DIFF
--- a/app/src/main/res/layout/fragment_about_us.xml
+++ b/app/src/main/res/layout/fragment_about_us.xml
@@ -8,29 +8,34 @@
 
     <ScrollView
         android:layout_width="match_parent"
-        android:layout_height="match_parent">
+        android:layout_height="match_parent"
+        android:background="@color/colorPrimaryDark">
 
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginBottom="@dimen/margin_extra_large"
             android:layout_marginTop="@dimen/margin_medium"
-            android:orientation="vertical">
+            android:background="@color/colorPrimaryDark"
+            android:orientation="vertical"
+            android:paddingBottom="@dimen/padding_medium">
 
             <!--About Susi -->
             <android.support.v7.widget.CardView
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:clickable="true"
                 android:layout_margin="@dimen/margin_small"
+                android:clickable="true"
                 android:focusable="true"
-                app:cardCornerRadius="@dimen/margin_small"
-                android:foreground="?attr/selectableItemBackground">
+                android:foreground="?attr/selectableItemBackground"
+                app:cardCornerRadius="@dimen/margin_small">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:paddingLeft="@dimen/padding_large"
+                    android:paddingRight="@dimen/padding_large">
 
                     <ImageView
                         android:layout_width="wrap_content"
@@ -44,6 +49,7 @@
                         android:id="@+id/about_susi"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
+                        android:layout_marginBottom="@dimen/padding_large"
                         android:layout_marginTop="@dimen/margin_moderate"
                         android:padding="@dimen/padding_small"
                         android:text="@string/susi_about"
@@ -59,13 +65,14 @@
                 android:layout_margin="@dimen/margin_small"
                 android:clickable="true"
                 android:focusable="true"
-                app:cardCornerRadius="@dimen/margin_small"
-                android:foreground="?attr/selectableItemBackground">
+                android:foreground="?attr/selectableItemBackground"
+                app:cardCornerRadius="@dimen/margin_small">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:padding="@dimen/padding_large">
 
                     <TextView
                         android:id="@+id/about_contributors"
@@ -73,8 +80,8 @@
                         android:layout_height="wrap_content"
                         android:padding="@dimen/padding_small"
                         android:text="@string/susi_contributors"
-                        android:textColor="@color/colorPrimary"
-                        android:textSize="@dimen/text_size_large"
+                        android:textColor="@color/colorPrimaryDark"
+                        android:textSize="@dimen/text_size_very_large"
                         android:textStyle="bold" />
 
                     <TextView
@@ -94,15 +101,16 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_margin="@dimen/margin_small"
-                app:cardCornerRadius="@dimen/margin_small"
                 android:clickable="true"
                 android:focusable="true"
-                android:foreground="?attr/selectableItemBackground">
+                android:foreground="?attr/selectableItemBackground"
+                app:cardCornerRadius="@dimen/margin_small">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:padding="@dimen/padding_large">
 
                     <TextView
                         android:id="@+id/about_susi_skill_cms"
@@ -111,7 +119,7 @@
                         android:padding="@dimen/padding_small"
                         android:text="@string/susi_skill_cms"
                         android:textColor="@color/colorPrimary"
-                        android:textSize="@dimen/text_size_large"
+                        android:textSize="@dimen/text_size_very_large"
                         android:textStyle="bold" />
 
                     <TextView
@@ -129,17 +137,18 @@
             <!-- About Reporting Issues -->
             <android.support.v7.widget.CardView
                 android:layout_width="match_parent"
-                app:cardCornerRadius="@dimen/margin_small"
                 android:layout_height="wrap_content"
                 android:layout_margin="@dimen/margin_small"
                 android:clickable="true"
                 android:focusable="true"
-                android:foreground="?attr/selectableItemBackground">
+                android:foreground="?attr/selectableItemBackground"
+                app:cardCornerRadius="@dimen/margin_small">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:padding="@dimen/padding_large">
 
                     <TextView
                         android:id="@+id/about_susi_report_issues"
@@ -148,7 +157,7 @@
                         android:padding="@dimen/padding_small"
                         android:text="@string/susi_report_issues"
                         android:textColor="@color/colorPrimary"
-                        android:textSize="@dimen/text_size_large"
+                        android:textSize="@dimen/text_size_very_large"
                         android:textStyle="bold" />
 
                     <TextView
@@ -168,18 +177,19 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginBottom="@dimen/margin_medium"
-                android:layout_marginTop="@dimen/margin_small"
                 android:layout_marginLeft="@dimen/margin_small"
                 android:layout_marginRight="@dimen/margin_small"
+                android:layout_marginTop="@dimen/margin_small"
                 android:clickable="true"
-                app:cardCornerRadius="@dimen/margin_small"
                 android:focusable="true"
-                android:foreground="?attr/selectableItemBackground">
+                android:foreground="?attr/selectableItemBackground"
+                app:cardCornerRadius="@dimen/margin_small">
 
                 <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical">
+                    android:orientation="vertical"
+                    android:padding="@dimen/padding_large">
 
                     <TextView
                         android:id="@+id/about_susi_license_info"
@@ -188,7 +198,7 @@
                         android:padding="@dimen/padding_small"
                         android:text="@string/susi_license_information"
                         android:textColor="@color/colorPrimary"
-                        android:textSize="@dimen/text_size_large"
+                        android:textSize="@dimen/text_size_very_large"
                         android:textStyle="bold" />
 
                     <TextView

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,4 +1,4 @@
-#Sun May 20 10:30:24 IST 2018
+#Sat Oct 13 10:24:08 IST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Fixes #1704 

Changes: Change UI of About us fragment according to material guidelines by adding appropriate ppaddings and margins.

Screenshots for the change: Before and after respectively
![screenshot_2018-10-12-21-14-07-991_ai susi](https://user-images.githubusercontent.com/30254676/46884628-20b39100-ce73-11e8-9d7d-53cf4e9ad0bd.png)
![screenshot_2018-10-12-21-56-22-147_ai susi](https://user-images.githubusercontent.com/30254676/46884631-24471800-ce73-11e8-8fe4-d5d4112542ce.png)

