### PR TITLE
fix: Remove leading and trailing whitespaces in input text

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatPresenter.kt
@@ -342,7 +342,7 @@ class ChatPresenter(chatActivity: ChatActivity) : IChatPresenter, IChatModel.OnR
         nonDeliveredMessages.add(Pair(query, newMessageIndex))
         databaseRepository.updateDatabase(ChatArgs(
                 prevId = newMessageIndex,
-                message = actual,
+                message = actual.trim(),
                 date = DateTimeHelper.date,
                 timeStamp = DateTimeHelper.currentTime,
                 mine = true,


### PR DESCRIPTION
Fixes #1806 

Changes: Removed leading and trailing whitespaces in input text
