### PR TITLE
fix: GoogleAppIndexingWarning in AndroidManifest.xml (#1815)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,14 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!-- Accepts URIs that begin with "https://chat.susi.ai/app" -->
+                <data android:host="chat.susi.ai" android:pathPrefix="/app" android:scheme="https" />
+            </intent-filter>
         </activity>
 
         <activity


### PR DESCRIPTION
Fixes #1815

Changes: Added intent-filter in `WelcomeActivity` for google app-indexing. 
Open will open now when-
1. User tries to open a url: https://chat.susi.ai/app
2. Or programmatically via `susi.ai://` 

Screenshots for the change: 
![susi-android-deep-linking](https://user-images.githubusercontent.com/9805036/50053272-16a25d00-0158-11e9-9bb8-5160d317a096.jpg)

![deep-link-susi](https://user-images.githubusercontent.com/9805036/50053275-20c45b80-0158-11e9-932d-01cf712a42e6.png)

