### PR TITLE
fix: App crash when trying to change server backend in settings

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -259,7 +259,7 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
             flag = true
         }
         customerServer.isChecked = flag
-        inputUrlText.setText(PrefManager.getString(Constant.CUSTOM_SERVER, null))
+        inputUrlText.setText(PrefManager.getString(Constant.CUSTOM_SERVER, " "))
         customerServer.setOnCheckedChangeListener { buttonView, isChecked ->
             if (isChecked)
                 inputUrl.visibility = View.VISIBLE

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -259,7 +259,7 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
             flag = true
         }
         customerServer.isChecked = flag
-        inputUrlText.setText(PrefManager.getString(Constant.CUSTOM_SERVER, " "))
+        inputUrlText.setText(PrefManager.getString(Constant.CUSTOM_SERVER, ""))
         customerServer.setOnCheckedChangeListener { buttonView, isChecked ->
             if (isChecked)
                 inputUrl.visibility = View.VISIBLE


### PR DESCRIPTION
Fixes : #1819 

Changes: Changed default value of CUSTOM_SERVER from null to "", which is required since the default value must be empty (not null) when the app is used for the first time.
