### PR TITLE
fix: Change the url of susi-skill in about-us

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -290,7 +290,7 @@
     <string name="susi_report_issues_desc">Please report all the issues in <a href="https://github.com/fossasia/susi_android/issues"><font color='#4184f3'>Github Repository Issue Tracker</font></a>.</string>
 
     <string name="susi_skill_cms">SUSI Skill CMS</string>
-    <string name="url_susi_skill_cms">http://www.skills.susi.ai</string>
+    <string name="url_susi_skill_cms">https://skills.susi.ai</string>
     <string name="susi_skill_cms_desc">SUSI is having many skills. You can look at the collection of skills at <a href="http://www.skills.susi.ai"><font color='#4184f3'>skills.susi.ai</font></a>. SUSI Skill development is easy and fun. You can edit existing skills or even create your own.</string>
 
     <!-- Intro Strings -->


### PR DESCRIPTION
Fixes #1821 

Changes: 
Changed the value of "url_susi_skill_cms" in strings.xml file from "http://www.skills.susi.ai" to "https://skills.susi.ai"

Screenshots for the change: 
![screenshot 261](https://user-images.githubusercontent.com/29620528/50353770-42b24980-056f-11e9-80d0-2e3a358a06f9.png)

