### PR TITLE
fix: Show the hidden text on about-us page

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -2,10 +2,12 @@ package org.fossasia.susi.ai.skills.aboutus
 
 
 import android.net.Uri
+import android.os.Build
 import android.os.Bundle
 import android.support.annotation.NonNull
 import android.support.customtabs.CustomTabsIntent
 import android.support.v4.app.Fragment
+import android.text.Html
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.View
@@ -43,29 +45,61 @@ class AboutUsFragment : Fragment() {
 
     @NonNull
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        about_susi.setOnClickListener({
+
+        if (Build.VERSION.SDK_INT >= 24) {
+            about_susi.text = Html.fromHtml(getString(R.string.susi_about), Html.FROM_HTML_OPTION_USE_CSS_COLORS) // for 24 api and more
+        } else {
+            about_susi.text = Html.fromHtml(getString(R.string.susi_about)) // or for older api
+        }
+
+        if (Build.VERSION.SDK_INT >= 24) {
+            contributors_desc.text = Html.fromHtml(getString(R.string.susi_contributors_desc), Html.FROM_HTML_OPTION_USE_CSS_COLORS) // for 24 api and more
+        } else {
+            contributors_desc.text = Html.fromHtml(getString(R.string.susi_contributors_desc)) // or for older api
+        }
+
+        if (Build.VERSION.SDK_INT >= 24) {
+            susi_skill_cms_desc.text = Html.fromHtml(getString(R.string.susi_skill_cms_desc), Html.FROM_HTML_OPTION_USE_CSS_COLORS) // for 24 api and more
+        } else {
+            susi_skill_cms_desc.text = Html.fromHtml(getString(R.string.susi_skill_cms_desc)) // or for older api
+        }
+
+        if (Build.VERSION.SDK_INT >= 24) {
+            susi_license_info_desc.text = Html.fromHtml(getString(R.string.susi_license_information_desc), Html.FROM_HTML_OPTION_USE_CSS_COLORS) // for 24 api and more
+        } else {
+            susi_license_info_desc.text = Html.fromHtml(getString(R.string.susi_license_information_desc)) // or for older api
+        }
+
+        if (Build.VERSION.SDK_INT >= 24) {
+            susi_report_issues_desc.text = Html.fromHtml(getString(R.string.susi_report_issues_desc), Html.FROM_HTML_OPTION_USE_CSS_COLORS) // for 24 api and more
+        } else {
+            susi_report_issues_desc.text = Html.fromHtml(getString(R.string.susi_report_issues_desc)) // or for older api
+        }
+
+
+        about_susi.setOnClickListener{
             val uri = Uri.parse(getString(R.string.url_about_susi))
             launchCustomtTab(uri)
-        })
+        }
 
-        contributors_desc.setOnClickListener({
+        contributors_desc.setOnClickListener{
             val uri = Uri.parse(getString(R.string.url_susi_contributors))
             launchCustomtTab(uri)
-        })
+        }
 
-        susi_skill_cms_desc.setOnClickListener({
+        susi_skill_cms_desc.setOnClickListener{
             val uri = Uri.parse(getString(R.string.url_susi_skill_cms))
             launchCustomtTab(uri)
-        })
+        }
 
-        susi_report_issues_desc.setOnClickListener({
+        susi_report_issues_desc.setOnClickListener{
             val uri = Uri.parse(getString(R.string.url_susi_report_issue))
             launchCustomtTab(uri)
-        })
-        susi_license_info_desc.setOnClickListener({
+        }
+        susi_license_info_desc.setOnClickListener{
             val uri = Uri.parse(getString(R.string.url_susi_license))
             launchCustomtTab(uri)
-        })
+        }
         super.onViewCreated(view, savedInstanceState)
     }
 

--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -45,11 +45,9 @@ class AboutUsFragment : Fragment() {
     }
 
     private fun htmlConverter(resourceId: Int): Spanned{
-        if(Build.VERSION.SDK_INT>24){
-            return Html.fromHtml(getString(resourceId),Html.FROM_HTML_OPTION_USE_CSS_COLORS)
-        }
-        else{
-            return Html.fromHtml(getString(resourceId))
+        return when {
+            Build.VERSION.SDK_INT>24 -> Html.fromHtml(getString(resourceId),Html.FROM_HTML_OPTION_USE_CSS_COLORS)
+            else -> @Suppress("DEPRECATION") Html.fromHtml(getString(resourceId))
         }
     }
 

--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -8,6 +8,7 @@ import android.support.annotation.NonNull
 import android.support.customtabs.CustomTabsIntent
 import android.support.v4.app.Fragment
 import android.text.Html
+import android.text.Spanned
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.View
@@ -43,14 +44,23 @@ class AboutUsFragment : Fragment() {
         super.onPrepareOptionsMenu(menu)
     }
 
+    private fun htmlConverter(resourceId: Int): Spanned{
+        if(Build.VERSION.SDK_INT>24){
+            return Html.fromHtml(getString(resourceId),Html.FROM_HTML_OPTION_USE_CSS_COLORS)
+        }
+        else{
+            return Html.fromHtml(getString(resourceId))
+        }
+    }
+
     @NonNull
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 
-        about_susi.text = Html.fromHtml(getString(R.string.susi_about))
-        contributors_desc.text = Html.fromHtml(getString(R.string.susi_contributors_desc))
-        susi_skill_cms_desc.text = Html.fromHtml(getString(R.string.susi_skill_cms_desc))
-        susi_license_info_desc.text = Html.fromHtml(getString(R.string.susi_license_information_desc))
-        susi_report_issues_desc.text = Html.fromHtml(getString(R.string.susi_report_issues_desc))
+        about_susi.text = htmlConverter(R.string.susi_about)
+        contributors_desc.text = htmlConverter(R.string.susi_contributors_desc)
+        susi_skill_cms_desc.text = htmlConverter(R.string.susi_skill_cms_desc)
+        susi_license_info_desc.text = htmlConverter(R.string.susi_license_information_desc)
+        susi_report_issues_desc.text = htmlConverter(R.string.susi_report_issues_desc)
 
 
         about_susi.setOnClickListener{

--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -46,35 +46,11 @@ class AboutUsFragment : Fragment() {
     @NonNull
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
 
-        if (Build.VERSION.SDK_INT >= 24) {
-            about_susi.text = Html.fromHtml(getString(R.string.susi_about), Html.FROM_HTML_OPTION_USE_CSS_COLORS) // for 24 api and more
-        } else {
-            about_susi.text = Html.fromHtml(getString(R.string.susi_about)) // or for older api
-        }
-
-        if (Build.VERSION.SDK_INT >= 24) {
-            contributors_desc.text = Html.fromHtml(getString(R.string.susi_contributors_desc), Html.FROM_HTML_OPTION_USE_CSS_COLORS) // for 24 api and more
-        } else {
-            contributors_desc.text = Html.fromHtml(getString(R.string.susi_contributors_desc)) // or for older api
-        }
-
-        if (Build.VERSION.SDK_INT >= 24) {
-            susi_skill_cms_desc.text = Html.fromHtml(getString(R.string.susi_skill_cms_desc), Html.FROM_HTML_OPTION_USE_CSS_COLORS) // for 24 api and more
-        } else {
-            susi_skill_cms_desc.text = Html.fromHtml(getString(R.string.susi_skill_cms_desc)) // or for older api
-        }
-
-        if (Build.VERSION.SDK_INT >= 24) {
-            susi_license_info_desc.text = Html.fromHtml(getString(R.string.susi_license_information_desc), Html.FROM_HTML_OPTION_USE_CSS_COLORS) // for 24 api and more
-        } else {
-            susi_license_info_desc.text = Html.fromHtml(getString(R.string.susi_license_information_desc)) // or for older api
-        }
-
-        if (Build.VERSION.SDK_INT >= 24) {
-            susi_report_issues_desc.text = Html.fromHtml(getString(R.string.susi_report_issues_desc), Html.FROM_HTML_OPTION_USE_CSS_COLORS) // for 24 api and more
-        } else {
-            susi_report_issues_desc.text = Html.fromHtml(getString(R.string.susi_report_issues_desc)) // or for older api
-        }
+        about_susi.text = Html.fromHtml(getString(R.string.susi_about))
+        contributors_desc.text = Html.fromHtml(getString(R.string.susi_contributors_desc))
+        susi_skill_cms_desc.text = Html.fromHtml(getString(R.string.susi_skill_cms_desc))
+        susi_license_info_desc.text = Html.fromHtml(getString(R.string.susi_license_information_desc))
+        susi_report_issues_desc.text = Html.fromHtml(getString(R.string.susi_report_issues_desc))
 
 
         about_susi.setOnClickListener{


### PR DESCRIPTION
Fixes #1825 

Changes: 
Added the code in the AboutUsFragement to change the HTML strings into displayabl text.

Screenshots for the change: 

Before

![screenshot_1546955453](https://user-images.githubusercontent.com/29620528/50835520-e9268900-137c-11e9-984a-3ff32321fc48.png)

After

![screenshot_1546955321](https://user-images.githubusercontent.com/29620528/50835523-eaf04c80-137c-11e9-87c2-a830cb981a8b.png)
