### PR TITLE
fix: Fixed app crash in skill when in landscape

### DIFF
--- a/app/src/main/res/layout-land/fragment_skill_details.xml
+++ b/app/src/main/res/layout-land/fragment_skill_details.xml
@@ -499,6 +499,15 @@
                 android:textSize="@dimen/text_size_large"
                 app:fontFamily="sans-serif" />
 
+            <TextView
+                android:id="@+id/reportSkill"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@color/md_white_1000"
+                android:text="@string/report_skill"
+                android:textSize="@dimen/text_size_medium"
+                android:visibility="gone" />
+
         </LinearLayout>
     </LinearLayout>
 </ScrollView>


### PR DESCRIPTION
Fixes #1876 

report skill setOnClickListener shows null value. Because there is no such resource in landscape layout file
Changes:
Added the reportSkill TextView in landscape layout resource
