### PR TITLE
fix: Use suitable layout on orientation change

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -1,6 +1,7 @@
 package org.fossasia.susi.ai.skills.skilldetails
 
 import android.content.Intent
+import android.content.res.Configuration
 import android.graphics.Color
 import android.net.Uri
 import android.os.Build
@@ -525,6 +526,15 @@ class SkillDetailsFragment : Fragment(), ISkillDetailsView {
         rvFeedback.setHasFixedSize(true)
         rvFeedback.layoutManager = mLayoutManager
         rvFeedback.adapter = FeedbackAdapter(requireContext(), feedbackResponse)
+    }
+
+    /**
+     * Switches to correct layout file on rotation
+     */
+    override fun onConfigurationChanged(newConfig: Configuration?) {
+        super.onConfigurationChanged(newConfig)
+        val activity = activity
+        activity?.supportFragmentManager?.beginTransaction()?.detach(this)?.attach(this)?.commit()
     }
 
     private fun setDynamicContent() {


### PR DESCRIPTION
Fixes #1925 Layout change does not change on orientation change
Changes: 
Detached and attached the fragment


Screenshots for the change: 
![whatsappvideo20190210at11 2](https://user-images.githubusercontent.com/31040431/52580703-e7098b80-2e4e-11e9-9272-f0f6d2ac2f07.gif)
