### PR TITLE
fix: Fixed selectable in settings

### DIFF
--- a/app/src/main/res/xml/pref_settings.xml
+++ b/app/src/main/res/xml/pref_settings.xml
@@ -6,6 +6,7 @@
     <PreferenceCategory android:title="Login email">
         <PreferenceScreen
             android:key="display_email"
+            android:selectable="false"
             android:title="test email"/>
     </PreferenceCategory>
 
@@ -77,6 +78,7 @@
 
         <PreferenceScreen
             android:key="device"
+            android:selectable="false"
             android:summary="Your device will be shown here when it is connected"
             android:title="@string/pref_devices_not_connected" />
 


### PR DESCRIPTION
Fixes #1700

Changes:
Disabled the selectable feature for "No Connected device"
And disabled selectable feature for "Login email" as there is no action required for these
