### PR TITLE
fix: One speech option selected at a time

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -8,6 +8,7 @@ import android.net.Uri
 import android.os.Bundle
 import android.support.design.widget.TextInputEditText
 import android.support.design.widget.TextInputLayout
+import android.support.v14.preference.SwitchPreference
 import android.support.v4.app.ActivityCompat
 import android.support.v7.app.AlertDialog
 import android.support.v7.preference.ListPreference
@@ -46,8 +47,8 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
     private lateinit var loginLogout: Preference
     private lateinit var resetPassword: Preference
     private lateinit var enterSend: Preference
-    private lateinit var speechAlways: Preference
-    private lateinit var speechOutput: Preference
+    private lateinit var speechAlways: SwitchPreference
+    private lateinit var speechOutput: SwitchPreference
     private lateinit var displayEmail: Preference
     lateinit var password: TextInputLayout
     private lateinit var newPassword: TextInputLayout
@@ -81,8 +82,8 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
         loginLogout = preferenceManager.findPreference(Constant.LOGIN_LOGOUT)
         resetPassword = preferenceManager.findPreference(Constant.RESET_PASSWORD)
         enterSend = preferenceManager.findPreference(getString(R.string.settings_enterPreference_key))
-        speechOutput = preferenceManager.findPreference(getString(R.string.settings_speechPreference_key))
-        speechAlways = preferenceManager.findPreference(getString(R.string.settings_speechAlways_key))
+        speechOutput = preferenceManager.findPreference(getString(R.string.settings_speechPreference_key)) as SwitchPreference
+        speechAlways = preferenceManager.findPreference(getString(R.string.settings_speechAlways_key)) as SwitchPreference
         displayEmail = preferenceManager.findPreference(getString(R.string.settings_displayEmail_key))
         querylanguage = preferenceManager.findPreference(Constant.LANG_SELECT) as ListPreference
         deviceName = preferenceManager.findPreference(Constant.DEVICE)
@@ -209,11 +210,19 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
 
             speechAlways.setOnPreferenceChangeListener { _, newValue ->
                 settingsPresenter.sendSetting(getString(R.string.settings_speechAlways_key), newValue.toString(), 1)
+                if (newValue.toString() == "true" && speechOutput.isChecked) {
+                    speechOutput.isChecked = false
+                    speechOutput.callChangeListener("false")
+                }
                 true
             }
 
             speechOutput.setOnPreferenceChangeListener { _, newValue ->
                 settingsPresenter.sendSetting(getString(R.string.settings_speechPreference_key), newValue.toString(), 1)
+                if (newValue.toString() == "true" && speechAlways.isChecked) {
+                    speechAlways.isChecked = false
+                    speechAlways.callChangeListener("false")
+                }
                 true
             }
         }


### PR DESCRIPTION
Fixes #1921 Contradicting options can be selected in settings 
Changes: 
Made one of the options false if other is made true by user

Screenshots for the change: 

![whatsappvideo20190213at30](https://user-images.githubusercontent.com/31040431/52701992-61e2bb80-2fa1-11e9-837f-8c21f6f10b07.gif)

