### PR TITLE
fix: Made search bar match parent

### DIFF
--- a/app/src/main/res/layout/search_bar.xml
+++ b/app/src/main/res/layout/search_bar.xml
@@ -6,7 +6,7 @@
 
     <EditText
         android:id="@+id/edtSearch"
-        android:layout_width="wrap_content"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/margin_moderate"
         android:background="@null"


### PR DESCRIPTION
Fixes #1372 


Changes: 
I think this the issue is because the "Search Skill" is wrapped and when we tap just left of cross icon the keyboard doesn't appear.
The solution for this is just making it match with parent.

Made the search bar match parent from wrap content

Screenshots for the change: 
