### PR TITLE
chore: sign up activity cancel dialog box updated

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/signup/SignUpActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/signup/SignUpActivity.kt
@@ -104,7 +104,7 @@ class SignUpActivity : AppCompatActivity(), ISignUpView {
         val alertMessage = getString(R.string.error_cancelling_signUp_process_text)
         val dialogTitle = getString(R.string.dialog_cancel_sign_up)
         val successAlertboxHelper = AlertboxHelper(this@SignUpActivity, dialogTitle, alertMessage, dialogClickListener, null,
-                resources.getString(R.string.cancel), resources.getString(R.string.Continue), resources.getColor(R.color
+                resources.getString(R.string.cancel), resources.getString(R.string.stay_here), resources.getColor(R.color
                 .md_blue_500))
         successAlertboxHelper.showAlertBox()
         checkDialog = true

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,7 +204,7 @@
     <string name="invalid_credentials">Invalid credentials. Please try again</string>
 
     <!-- Settings Activity-->
-    <string name="Continue">Continue</string>
+    <string name="stay_here">Stay here</string>
 
     <string name="email_id_input">Enter your e-mail ID</string>
     <string name="email_pass_not_exists">E-mail address does not exist. Please make sure you have entered it correctly.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -204,6 +204,7 @@
     <string name="invalid_credentials">Invalid credentials. Please try again</string>
 
     <!-- Settings Activity-->
+    <string name="Continue">Continue</string>
     <string name="stay_here">Stay here</string>
 
     <string name="email_id_input">Enter your e-mail ID</string>


### PR DESCRIPTION
Changes: On pressing back button at sign up activity, a dialog box appears for confirmation which is a bit confusing. You can see in the below image that both options can be thought as the option to exit the activity by different users. So I've updated the text so as to provide convinient options.

Before:
![screenshot_2019-02-28-19-17-31](https://user-images.githubusercontent.com/31595908/53571329-a61faf80-3b8e-11e9-9db3-3293b87e4536.png)

After:
![screenshot_2019-02-28-19-18-43](https://user-images.githubusercontent.com/31595908/53571297-943e0c80-3b8e-11e9-830c-8731046fcf58.png)
