### PR TITLE
fix: User's message should be ticked before SUSI's reply

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/adapters/viewholders/ChatViewHolder.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/adapters/viewholders/ChatViewHolder.kt
@@ -27,6 +27,7 @@ import timber.log.Timber
 import kotterknife.bindOptionalView
 import kotterknife.bindView
 import org.fossasia.susi.ai.chat.adapters.recycleradapters.ChatFeedRecyclerAdapter
+import org.fossasia.susi.ai.helper.NetworkUtils
 
 class ChatViewHolder(view: View, clickListener: MessageViewHolder.ClickListener, myMessage: Int) : MessageViewHolder(view, clickListener) {
 
@@ -53,7 +54,7 @@ class ChatViewHolder(view: View, clickListener: MessageViewHolder.ClickListener,
                     ChatFeedRecyclerAdapter.USER_MESSAGE -> {
                         chatTextView.text = model.content
                         timeStamp.text = model.timeStamp
-                        if (model.isDelivered) {
+                        if (NetworkUtils.isNetworkConnected()) {
                             receivedTick?.setImageResource(R.drawable.ic_check)
                         } else {
                             receivedTick?.setImageResource(R.drawable.ic_clock)


### PR DESCRIPTION
Fixes #1990 

Changes: The check to display tick is changed in a way that if the network connection is available, the message gets ticked indicating that the message is sent.  

Screenshots for the change: 

![susi-tick-pr](https://user-images.githubusercontent.com/26673203/53681028-6a5d2500-3d09-11e9-9b1d-21cb7464836e.gif)
