### PR TITLE
fix: Show search results when searching in skills activity

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ apply plugin: 'kotlin-kapt'
 apply plugin: 'realm-android'
 
 def YOUTUBE_API_KEY = System.getenv('YOUTUBE_API_KEY') ?: "YOUR_API_KEY"
-def MAPBOX_API_KEY = '"'+System.getenv('MAPBOX_API_KEY')+'"' ?: '"DEFAULT"'
+def MAPBOX_API_KEY = '"' + System.getenv('MAPBOX_API_KEY') + '"' ?: '"DEFAULT"'
 
 android {
     compileSdkVersion rootConfiguration.compileSdkVersion
@@ -151,4 +151,9 @@ dependencies {
     implementation "com.jakewharton.timber:timber:${rootConfiguration.timberVersion}"
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${rootConfiguration.kotlinVersion}"
+
+
+    implementation "android.arch.lifecycle:livedata"
+
+
 }

--- a/app/src/main/java/org/fossasia/susi/ai/data/SkillDetailsModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/SkillDetailsModel.kt
@@ -52,6 +52,7 @@ class SkillDetailsModel : ISkillDetailsModel {
 
         updateRatingsResponseCall.enqueue(object : Callback<FiveStarSkillRatingResponse> {
             override fun onResponse(call: Call<FiveStarSkillRatingResponse>, response: Response<FiveStarSkillRatingResponse>) {
+
                 listener.onSkillDetailsModelSuccess(response)
             }
 
@@ -67,6 +68,7 @@ class SkillDetailsModel : ISkillDetailsModel {
 
         updateUserRatingResponseCall.enqueue(object : Callback<GetRatingByUserResponse> {
             override fun onResponse(call: Call<GetRatingByUserResponse>, response: Response<GetRatingByUserResponse>) {
+
                 listener.onUpdateUserRatingModelSuccess(response)
             }
 
@@ -82,6 +84,7 @@ class SkillDetailsModel : ISkillDetailsModel {
 
         reportSkillResponseCall.enqueue(object : Callback<ReportSkillResponse> {
             override fun onResponse(call: Call<ReportSkillResponse>?, response: Response<ReportSkillResponse>) {
+
                 listener.reportSendSuccess(response)
             }
 

--- a/app/src/main/java/org/fossasia/susi/ai/data/SkillListingModel.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/data/SkillListingModel.kt
@@ -28,6 +28,7 @@ class SkillListingModel : ISkillListingModel {
 
         authResponseCallGroups.enqueue(object : Callback<ListGroupsResponse> {
             override fun onResponse(call: Call<ListGroupsResponse>, response: Response<ListGroupsResponse>) {
+
                 listener.onGroupFetchSuccess(response)
             }
 
@@ -45,6 +46,13 @@ class SkillListingModel : ISkillListingModel {
 
         authResponseCallSkills.enqueue(object : Callback<ListSkillsResponse> {
             override fun onResponse(call: Call<ListSkillsResponse>, response: Response<ListSkillsResponse>) {
+                val body = response.body()
+                body?.apply {
+                    Timber.d("this.group ${this.group}")
+                    Timber.d("skillMap $skillMap")
+                    Timber.d("filteredSkillsData $filteredSkillsData")
+                }
+
                 listener.onSkillFetchSuccess(response, group)
             }
 
@@ -61,11 +69,13 @@ class SkillListingModel : ISkillListingModel {
 
         authResponseCallMetrics.enqueue(object : Callback<ListSkillMetricsResponse> {
             override fun onResponse(call: Call<ListSkillMetricsResponse>, response: Response<ListSkillMetricsResponse>) {
+
                 listener.onSkillMetricsFetchSuccess(response)
             }
 
             override fun onFailure(call: Call<ListSkillMetricsResponse>, t: Throwable) {
                 Timber.e(t)
+
                 listener.onSkillMetricsFetchFailure(t)
             }
         })

--- a/app/src/main/java/org/fossasia/susi/ai/device/DeviceActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/device/DeviceActivity.kt
@@ -10,7 +10,7 @@ import org.fossasia.susi.ai.device.deviceconnect.DeviceConnectFragment
 
 /*
 *   Created by batbrain7 on 20/06/18
-*   Device activity is where we can setup a new device and also
+*   Device appActivity is where we can setup a new device and also
 *   view the devices currently connected
  */
 

--- a/app/src/main/java/org/fossasia/susi/ai/helper/AlertboxHelper.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/AlertboxHelper.kt
@@ -13,7 +13,7 @@ class AlertboxHelper
 /**
  * Instantiates a new Alertbox helper.
 
- * @param activity the activity
+ * @param activity the appActivity
  * *
  * @param title the title
  * *

--- a/app/src/main/java/org/fossasia/susi/ai/helper/Utils.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/Utils.kt
@@ -92,4 +92,12 @@ object Utils {
         val inputManager: InputMethodManager = context?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
         inputManager.hideSoftInputFromWindow(view.windowToken, InputMethodManager.SHOW_FORCED)
     }
+
+    fun showSoftKeyboard(context: Context?, view: View) {
+        val imm = context?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
+
+    }
+
+
 }

--- a/app/src/main/java/org/fossasia/susi/ai/helper/Utils.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/Utils.kt
@@ -93,11 +93,13 @@ object Utils {
         inputManager.hideSoftInputFromWindow(view.windowToken, InputMethodManager.SHOW_FORCED)
     }
 
+    /**
+     * utility function to show keyboard
+     */
     fun showSoftKeyboard(context: Context?, view: View) {
-        val imm = context?.getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager
+        val imm: InputMethodManager = context
+                ?.getSystemService(Context.INPUT_METHOD_SERVICE) as? InputMethodManager
+                ?: throw ClassCastException("Wrong type of system service received.")
         imm.showSoftInput(view, InputMethodManager.SHOW_IMPLICIT)
-
     }
-
-
 }

--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
@@ -22,8 +22,8 @@ import org.fossasia.susi.ai.login.contract.ILoginView
 import org.fossasia.susi.ai.signup.SignUpActivity
 
 /**
- * <h1>The Login activity.</h1>
- * <h2>This activity is used to login into the app.</h2>
+ * <h1>The Login appActivity.</h1>
+ * <h2>This appActivity is used to login into the app.</h2>
  *
  * Created by chiragw15 on 4/7/17.
  */

--- a/app/src/main/java/org/fossasia/susi/ai/signup/SignUpActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/signup/SignUpActivity.kt
@@ -21,8 +21,8 @@ import org.fossasia.susi.ai.signup.contract.ISignUpPresenter
 import org.fossasia.susi.ai.signup.contract.ISignUpView
 
 /**
- * <h1>The SignUp activity.</h1>
- * <h2>This activity is used to signUp into the app.</h2>
+ * <h1>The SignUp appActivity.</h1>
+ * <h2>This appActivity is used to signUp into the app.</h2>
  *
  * Created by mayanktripathi on 05/07/17.
  */

--- a/app/src/main/java/org/fossasia/susi/ai/skills/LayoutManagerSmoothScroller.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/LayoutManagerSmoothScroller.kt
@@ -1,0 +1,40 @@
+package org.fossasia.susi.ai.skills
+
+import android.content.Context
+import android.graphics.PointF
+import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.LinearSmoothScroller
+import android.support.v7.widget.RecyclerView
+
+
+/**
+ * Custom LayoutManager to smoothly scroll the list to the top when the user hits
+ * the back space and the results changes by a great amount
+ */
+class LayoutManagerSmoothScroller(context: Context) : LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false) {
+
+
+    /**
+     *  smoothly scrolls the result of the list to the top
+     * @param recyclerView [RecyclerView] on which scroll is to happen
+     * @param state [RecyclerView.State] same as super method
+     * @param position position to which the scroll is to be applied
+     */
+    override fun smoothScrollToPosition(recyclerView: RecyclerView, state: RecyclerView.State?, position: Int) {
+        val smoothScroller = TopSnappedSmoothScroller(recyclerView.context)
+        smoothScroller.targetPosition = position
+        startSmoothScroll(smoothScroller)
+    }
+
+    private inner class TopSnappedSmoothScroller(context: Context) : LinearSmoothScroller(context) {
+
+        override fun computeScrollVectorForPosition(targetPosition: Int): PointF? {
+            return this@LayoutManagerSmoothScroller
+                    .computeScrollVectorForPosition(targetPosition)
+        }
+
+        override fun getVerticalSnapPreference(): Int {
+            return LinearSmoothScroller.SNAP_TO_START
+        }
+    }
+}

--- a/app/src/main/java/org/fossasia/susi/ai/skills/LayoutManagerSmoothScroller.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/LayoutManagerSmoothScroller.kt
@@ -6,13 +6,11 @@ import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.LinearSmoothScroller
 import android.support.v7.widget.RecyclerView
 
-
 /**
  * Custom LayoutManager to smoothly scroll the list to the top when the user hits
  * the back space and the results changes by a great amount
  */
 class LayoutManagerSmoothScroller(context: Context) : LinearLayoutManager(context, LinearLayoutManager.VERTICAL, false) {
-
 
     /**
      *  smoothly scrolls the result of the list to the top

--- a/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
@@ -5,7 +5,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.support.v4.app.FragmentManager
 import android.support.v7.app.AppCompatActivity
-import android.text.TextUtils
 import android.view.Menu
 import android.view.MenuItem
 import android.widget.EditText
@@ -54,14 +53,11 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
                 .addToBackStack(TAG_SKILLS_FRAGMENT)
                 .commit()
 
-
         supportFragmentManager.addOnBackStackChangedListener {
             invalidateOptionsMenu()
         }
         skills = skillFragment.skills
-
     }
-
 
     override fun onBackPressed() {
         val fragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
@@ -74,7 +70,6 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
                 isSearchOpened = false
                 searchAction?.icon = resources.getDrawable(R.drawable.ic_open_search)
                 openSkillsFragment(supportFragmentManager)
-
             }
             is SkillListingFragment -> {
                 finish()
@@ -83,21 +78,16 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
                 val intent = Intent(this, ChatActivity::class.java)
                 intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
                 startActivity(intent)
-
             }
             else -> return super.onBackPressed()
         }
-
-
     }
 
     override fun onPrepareOptionsMenu(menu: Menu?): Boolean {
         super.onPrepareOptionsMenu(menu)
 
-
         SkillListingPresenter.showMenuIcon.apply {
             value = false
-
         }
         val currentFragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
         when (currentFragment) {
@@ -113,16 +103,13 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
                     }
                     if (it == null) {
                         menu?.findItem(R.id.action_search)?.isVisible = false
-
                     }
-
                 })
             }
             else -> menu?.setGroupVisible(R.id.menu_items, false)
         }
 
         return super.onPrepareOptionsMenu(menu)
-
     }
 
     override fun onCreateOptionsMenu(menu: Menu?): Boolean {
@@ -134,16 +121,8 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         skillNames = skillNames()
 
-
-
         when (item.itemId) {
             android.R.id.home -> {
-//                val currentFragment = supportFragmentManager.findFragmentById(R.id.fragment_container)
-//                if (!(currentFragment is SkillListingFragment))
-//                    openSkillsFragment(supportFragmentManager)
-//                else {
-//                    super.onBackPressed()
-//                    backHandler(this)
                 onHomeButtonPressed()
                 return true
             }
@@ -169,16 +148,12 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
                 supportActionBar?.setCustomView(R.layout.search_bar)//add the custom view
                 handleMenuSearch()
                 openSearchFragment(supportFragmentManager, skillNames, SEARCH_FRAGMENT_TAG)
-
             }
-
-
         }
         return super.onOptionsItemSelected(item)
     }
 
     private fun gotoSkillFragment(fragmentManager: FragmentManager) {
-
 
         if (supportFragmentManager.findFragmentById(R.id.fragment_container) is SkillListingFragment) {
             finish()
@@ -195,21 +170,19 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
         // If search fragment wasn't found in the backstack...
 
         gotoSkillFragment(supportFragmentManager)
-
     }
 
+    private fun openSearchFragment(
+        fragmentManager: FragmentManager,
 
-    private fun openSearchFragment(fragmentManager: FragmentManager,
-
-
-                                   skillNames: ArrayList<SkillData>,
-                                   searcH_FRAGMENT_TAG: String) {
+        skillNames: ArrayList<SkillData>,
+        searcH_FRAGMENT_TAG: String
+    ) {
         fragmentManager.beginTransaction()
                 .setCustomAnimations(R.animator.custom_fade_in, R.animator.custom_fade_out, R.animator.custom_fade_in, R.animator.custom_fade_out)
                 .replace(R.id.fragment_container, SearchFragment.getInstance(skillNames), searcH_FRAGMENT_TAG)
                 .commit()
     }
-
 
     override fun loadDetailFragment(skillData: SkillData?, skillGroup: String?, skillTag: String) {
         handleOnLoadingFragment()
@@ -240,27 +213,17 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
         }
     }
 
-
     private fun skillNames(): ArrayList<SkillData> {
-        val list: ArrayList<String> = ArrayList()
         val skillsData: ArrayList<SkillData> = ArrayList()
-        skills.forEach {
-            if (it.second != null) {
-                it.second.forEach { skilldata ->
-                    var flag = false
-                    list.forEach { skillname ->
-                        if (skilldata.skillName != null && skillname.contains(skilldata.skillName, false)) {
-                            flag = true
-                        }
-                    }
-                    if (skilldata.skillName != null && skilldata.skillName != this.getString(R.string.no_skill_name) && !TextUtils.isEmpty(skilldata.skillName) && !flag) {
-                        list.add(skilldata.skillName)
-                        skillsData.add(skilldata)
-                    }
+        val skillList = skills
+                .flatMap { it.second }.asSequence()
+                .distinctBy { skillData -> skillData.skillName }
+                .filter { skillData ->
+                    !skillData.skillName.isNullOrBlank() &&
+                            skillData.skillName != getString(R.string.no_skill_name)
+                }.toList()
 
-                }
-            }
-        }
+        skillsData.addAll(skillList)
         return skillsData
     }
 
@@ -292,7 +255,6 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
         }
     }
 
-
     private fun openSkillsFragment(fragmentManager: FragmentManager) {
         val action = supportActionBar
         action?.setDisplayShowCustomEnabled(false)
@@ -306,4 +268,3 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
                 .commit()
     }
 }
-

--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/GroupWiseSkillsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/GroupWiseSkillsFragment.kt
@@ -1,20 +1,16 @@
 package org.fossasia.susi.ai.skills.groupwiseskills
 
 import android.content.Context
-import android.support.v4.app.Fragment
 import android.os.Bundle
 import android.support.annotation.NonNull
+import android.support.v4.app.Fragment
 import android.support.v4.widget.SwipeRefreshLayout
 import android.support.v7.widget.LinearLayoutManager
 import android.support.v7.widget.SnapHelper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import kotlinx.android.synthetic.main.fragment_group_wise_skill_listing.groupWiseSkills
-import kotlinx.android.synthetic.main.fragment_group_wise_skill_listing.swipeRefreshLayout
-import kotlinx.android.synthetic.main.fragment_group_wise_skill_listing.progressSkillWait
-import kotlinx.android.synthetic.main.fragment_group_wise_skill_listing.messageNoSkillsFound
-import kotlinx.android.synthetic.main.fragment_group_wise_skill_listing.errorSkillFetch
+import kotlinx.android.synthetic.main.fragment_group_wise_skill_listing.*
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.dataclasses.GroupWiseSkills
 import org.fossasia.susi.ai.helper.SimpleDividerItemDecoration
@@ -52,6 +48,8 @@ class GroupWiseSkillsFragment : Fragment(), IGroupWiseSkillsView, SwipeRefreshLa
         if (argument != null) {
             this.skills.group = argument.getString("group")
         }
+        Timber.d("onCreateView")
+
         return inflater.inflate(R.layout.fragment_group_wise_skill_listing, container, false)
     }
 

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/AnimationUtils.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/AnimationUtils.kt
@@ -5,12 +5,10 @@ import android.animation.AnimatorListenerAdapter
 import android.support.v4.view.animation.FastOutSlowInInterpolator
 import android.view.View
 
-
 /**
  * Animation Utils class helps to animate the views
  */
 object AnimationUtils {
-
 
     /**
      * Animate the view
@@ -42,9 +40,7 @@ object AnimationUtils {
         view.visibility = View.VISIBLE
 
         animateLightSlideAndAlpha(view, enterOrExit, duration, delay, execOnEnd)
-
     }
-
 
     private fun animateLightSlideAndAlpha(view: View, enterOrExit: Boolean, duration: Long, delay: Long, execOnEnd: Runnable?) {
         if (enterOrExit) {

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/AnimationUtils.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/AnimationUtils.kt
@@ -1,0 +1,69 @@
+package org.fossasia.susi.ai.skills.skilllisting
+
+import android.animation.Animator
+import android.animation.AnimatorListenerAdapter
+import android.support.v4.view.animation.FastOutSlowInInterpolator
+import android.view.View
+
+
+/**
+ * Animation Utils class helps to animate the views
+ */
+object AnimationUtils {
+
+
+    /**
+     * Animate the view
+     *
+     * @param view view that will be animated
+     * @param enterOrExit true to enter, false to exit
+     * @param duration how long the animation will take, in milliseconds
+     * @param delay how long the animation will wait to start, in milliseconds
+     * @param execOnEnd runnable that will be executed when the animation ends
+     */
+    @JvmOverloads
+    fun animateView(view: View, enterOrExit: Boolean, duration: Long, delay: Long = 0, execOnEnd: Runnable? = null) {
+
+        if (view.visibility == View.VISIBLE && enterOrExit) {
+            view.animate().setListener(null).cancel()
+            view.visibility = View.VISIBLE
+            view.alpha = 1f
+            execOnEnd?.run()
+            return
+        } else if ((view.visibility == View.GONE || view.visibility == View.INVISIBLE) && !enterOrExit) {
+            view.animate().setListener(null).cancel()
+            view.visibility = View.GONE
+            view.alpha = 0f
+            execOnEnd?.run()
+            return
+        }
+
+        view.animate().setListener(null).cancel()
+        view.visibility = View.VISIBLE
+
+        animateLightSlideAndAlpha(view, enterOrExit, duration, delay, execOnEnd)
+
+    }
+
+
+    private fun animateLightSlideAndAlpha(view: View, enterOrExit: Boolean, duration: Long, delay: Long, execOnEnd: Runnable?) {
+        if (enterOrExit) {
+            view.translationY = (-view.height / 2).toFloat()
+            view.alpha = 0f
+            view.animate().setInterpolator(FastOutSlowInInterpolator()).alpha(1f).translationY(0f)
+                    .setDuration(duration).setStartDelay(delay).setListener(object : AnimatorListenerAdapter() {
+                        override fun onAnimationEnd(animation: Animator) {
+                            execOnEnd?.run()
+                        }
+                    }).start()
+        } else {
+            view.animate().setInterpolator(FastOutSlowInInterpolator()).alpha(0f).translationY((-view.height / 2).toFloat())
+                    .setDuration(duration).setStartDelay(delay).setListener(object : AnimatorListenerAdapter() {
+                        override fun onAnimationEnd(animation: Animator) {
+                            view.visibility = View.GONE
+                            execOnEnd?.run()
+                        }
+                    }).start()
+        }
+    }
+}

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SearchFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SearchFragment.kt
@@ -23,6 +23,7 @@ import org.fossasia.susi.ai.skills.SkillFragmentCallback
 import org.fossasia.susi.ai.skills.skilllisting.AnimationUtils.animateView
 import org.fossasia.susi.ai.skills.skilllisting.adapters.recycleradapters.SkillListAdapter
 import timber.log.Timber
+import java.lang.IllegalArgumentException
 
 /**
  * fragment to show the list of results for the search
@@ -65,7 +66,7 @@ class SearchFragment : Fragment() {
                     ?: throw IllegalStateException("context must be AppCompatActivity")
         }
         skillNames = arguments?.getParcelableArrayList("KEY_ARRAYLIST")
-                ?: throw Exception("parcelable list must be passed as arguments for search fragment")
+                ?: throw IllegalArgumentException("parcelable list must be passed as arguments for search fragment")
         skillNames.sortBy {
             it.skillName
         }
@@ -102,11 +103,6 @@ class SearchFragment : Fragment() {
         }
     }
 
-    <<<<<<< HEAD
-    =======
-
-
-    >>>>>>> 0ec023078edf66e09bcf3749423dc9c891f090f5
     override fun onViewCreated(rootView: View, savedInstanceState: Bundle?) {
         super.onViewCreated(rootView, savedInstanceState)
         val editText = appActivity?.supportActionBar?.customView?.findViewById<EditText>(R.id.edtSearch)
@@ -115,10 +111,8 @@ class SearchFragment : Fragment() {
         items_list.adapter = infoListAdapter
         items_list.layoutManager = LayoutManagerSmoothScroller(appActivity)
 
-        <<<<<<< HEAD
         initSearchListeners()
         infoListAdapter.submitList(skillNames)
-        ====== =
     }
 
     private fun initSearchListeners() {

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SearchFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SearchFragment.kt
@@ -1,0 +1,224 @@
+package org.fossasia.susi.ai.skills.skilllisting
+
+import android.app.Activity
+import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.support.v7.app.AppCompatActivity
+import android.text.Editable
+import android.text.TextUtils
+import android.text.TextWatcher
+import android.view.KeyEvent
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.view.inputmethod.EditorInfo
+import android.widget.EditText
+import android.widget.Toast
+import kotlinx.android.synthetic.main.fragment_search.items_list
+import kotlinx.android.synthetic.main.fragment_search.list_panel
+import org.fossasia.susi.ai.R
+import org.fossasia.susi.ai.helper.Utils
+import org.fossasia.susi.ai.rest.responses.susi.SkillData
+import org.fossasia.susi.ai.skills.LayoutManagerSmoothScroller
+import org.fossasia.susi.ai.skills.SkillFragmentCallback
+import org.fossasia.susi.ai.skills.skilllisting.AnimationUtils.animateView
+import org.fossasia.susi.ai.skills.skilllisting.adapters.recycleradapters.SkillListAdapter
+import timber.log.Timber
+
+/**
+ * fragment to show the list of results for the search
+ */
+open class SearchFragment : Fragment() {
+    lateinit var edtSearch: EditText
+    private var textWatcher: TextWatcher? = null
+    private var searchString: String? = null
+    lateinit var appActivity: AppCompatActivity
+    private lateinit var skillNames: ArrayList<SkillData>
+    private lateinit var skillCallback: SkillFragmentCallback
+    private lateinit var infoListAdapter: SkillListAdapter
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        return inflater.inflate(R.layout.fragment_search, container, false)
+    }
+
+    /**
+     * companion object to provide an instance of Search Fragment
+     */
+    companion object {
+        /**
+         * @param skillNames [SkillData] list to be provided to the Search Fragment to perform search upon.
+         */
+        fun getInstance(skillNames: ArrayList<SkillData>): SearchFragment {
+            val searchFragment = SearchFragment()
+            val bundle = Bundle()
+            bundle.putParcelableArrayList("KEY_ARRAYLIST", skillNames)
+            searchFragment.arguments = bundle
+            return searchFragment
+        }
+    }
+
+
+    override fun onAttach(activity: Activity?) {
+        super.onAttach(activity)
+
+        when (context) {
+            is AppCompatActivity -> this.appActivity = context as AppCompatActivity
+        }
+        skillNames = arguments?.getParcelableArrayList("KEY_ARRAYLIST")!!
+        skillNames.sortBy {
+            it.skillName
+
+        }
+        if (context is SkillFragmentCallback) {
+            skillCallback = context as SkillFragmentCallback
+        } else {
+            Timber.e("context is not SkillFragmentCallback")
+        }
+        infoListAdapter = SkillListAdapter(appActivity, skillNames, skillCallback, search = true)
+
+
+    }
+
+    private fun hideKeyboardSearch() {
+        if (edtSearch == null) return
+
+
+        Utils.hideSoftKeyboard(appActivity, edtSearch)
+
+        if (edtSearch != null) edtSearch.clearFocus()
+    }
+
+    override fun onPause() {
+        super.onPause()
+        hideKeyboardSearch()
+
+    }
+
+    override fun onResume() {
+        super.onResume()
+
+        if (TextUtils.isEmpty(searchString)) {
+            showKeyboardSearch()
+            showSuggestionsPanel()
+        } else {
+            hideKeyboardSearch()
+            hideListPanel()
+        }
+    }
+
+    private fun hideListPanel() {
+        if (list_panel != null) animateView(list_panel, false, 200)
+    }
+
+    private fun showKeyboardSearch() {
+        if (edtSearch == null) return
+
+        if (edtSearch.requestFocus()) {
+            Utils.showSoftKeyboard(appActivity, edtSearch)
+        }
+
+
+    }
+
+
+    override fun onViewCreated(rootView: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(rootView, savedInstanceState)
+        val editText = appActivity?.supportActionBar?.customView?.findViewById<EditText>(R.id.edtSearch)
+        if (editText != null) edtSearch = editText
+        edtSearch.setText(searchString)
+        initViews()
+
+        initSearchListeners()
+        infoListAdapter.submitList(skillNames)
+    }
+
+
+    private fun initViews() {
+
+        items_list.adapter = infoListAdapter
+        items_list.layoutManager = LayoutManagerSmoothScroller(appActivity)
+    }
+
+    private fun showSuggestionsPanel() {
+        if (list_panel != null) animateView(list_panel, true, 200)
+    }
+
+
+    private fun initSearchListeners() {
+
+        edtSearch.setOnClickListener {
+
+            showSuggestionsPanel()
+
+        }
+
+        edtSearch.setOnFocusChangeListener { _: View, hasFocus: Boolean ->
+            if (hasFocus) {
+                showSuggestionsPanel()
+            }
+        }
+
+
+
+        if (textWatcher != null) edtSearch.removeTextChangedListener(textWatcher)
+        textWatcher = object : TextWatcher {
+            override fun beforeTextChanged(s: CharSequence, start: Int, count: Int, after: Int) {}
+
+            override fun onTextChanged(s: CharSequence, start: Int, before: Int, count: Int) {}
+
+            override fun afterTextChanged(s: Editable) {
+                val newText = edtSearch.text.toString()
+                // search newText in the list
+                performSearch(newText)
+
+            }
+        }
+        edtSearch.addTextChangedListener(textWatcher)
+        edtSearch.setOnEditorActionListener { _, _, event ->
+            if (event != null && (event.keyCode == KeyEvent.KEYCODE_ENTER || event.action == EditorInfo.IME_ACTION_SEARCH)) {
+                performSearch(edtSearch.text.toString())
+                return@setOnEditorActionListener true
+            }
+            false
+        }
+    }
+
+    private fun performSearch(query: String) {
+        val result = ArrayList<SkillData>()
+        var flag = 0
+
+        skillNames
+                .filter { item ->
+                    Timber.d("item $item")
+
+                    item.skillName.toLowerCase().contains(query.toLowerCase())
+                }
+                .also { results ->
+                    Timber.d("$results")
+                    result += results
+                    Timber.d("$result")
+
+                    if (result.isNotEmpty()) flag = 1
+                }
+
+        Timber.d("flag $flag")
+
+
+        when (flag) {
+            1 -> {
+                items_list.smoothScrollToPosition(0)
+                infoListAdapter.setSkillList(result)
+                infoListAdapter.submitList(result)
+
+
+            }
+            else -> {
+                infoListAdapter.submitList(result)
+                Toast.makeText(context, "No skill found", Toast.LENGTH_SHORT).show()
+            }
+        }
+    }
+
+
+}
+

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
@@ -10,19 +10,19 @@ import android.support.v7.widget.SnapHelper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import kotlinx.android.synthetic.main.fragment_skill_listing.swipe_refresh_layout
-import kotlinx.android.synthetic.main.fragment_skill_listing.skillMetrics
-import kotlinx.android.synthetic.main.fragment_skill_listing.progressSkillWait
 import kotlinx.android.synthetic.main.fragment_skill_listing.errorSkillFetch
+import kotlinx.android.synthetic.main.fragment_skill_listing.progressSkillWait
+import kotlinx.android.synthetic.main.fragment_skill_listing.skillMetrics
+import kotlinx.android.synthetic.main.fragment_skill_listing.swipe_refresh_layout
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.dataclasses.SkillsBasedOnMetrics
+import org.fossasia.susi.ai.helper.SimpleDividerItemDecoration
 import org.fossasia.susi.ai.helper.StartSnapHelper
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
 import org.fossasia.susi.ai.skills.SkillFragmentCallback
 import org.fossasia.susi.ai.skills.skilllisting.adapters.recycleradapters.SkillMetricsAdapter
 import org.fossasia.susi.ai.skills.skilllisting.contract.ISkillListingPresenter
 import org.fossasia.susi.ai.skills.skilllisting.contract.ISkillListingView
-import org.fossasia.susi.ai.helper.SimpleDividerItemDecoration
 import timber.log.Timber
 
 /**
@@ -34,6 +34,7 @@ class SkillListingFragment : Fragment(), ISkillListingView, SwipeRefreshLayout.O
     private lateinit var skillAdapterSnapHelper: SnapHelper
     private lateinit var skillListingPresenter: ISkillListingPresenter
     var skills: ArrayList<Pair<String, List<SkillData>>> = ArrayList()
+
     private var metrics = SkillsBasedOnMetrics(ArrayList(), ArrayList(), ArrayList())
     private lateinit var skillMetricsAdapter: SkillMetricsAdapter
     private lateinit var skillCallback: SkillFragmentCallback
@@ -50,6 +51,7 @@ class SkillListingFragment : Fragment(), ISkillListingView, SwipeRefreshLayout.O
         swipe_refresh_layout.setOnRefreshListener(this)
         setUPAdapter()
         skillListingPresenter.getMetrics(swipe_refresh_layout.isRefreshing)
+
         super.onViewCreated(view, savedInstanceState)
     }
 
@@ -95,7 +97,7 @@ class SkillListingFragment : Fragment(), ISkillListingView, SwipeRefreshLayout.O
     }
 
     override fun updateSkillsAdapter(skills: ArrayList<Pair<String, List<SkillData>>>) {
-        swipe_refresh_layout.isRefreshing = false
+        if (swipe_refresh_layout != null) swipe_refresh_layout.isRefreshing = false
         if (errorSkillFetch.visibility == View.VISIBLE) {
             errorSkillFetch.visibility = View.GONE
         }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingPresenter.kt
@@ -1,5 +1,6 @@
 package org.fossasia.susi.ai.skills.skilllisting
 
+import android.arch.lifecycle.MutableLiveData
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.data.SkillListingModel
 import org.fossasia.susi.ai.data.UtilModel
@@ -8,10 +9,10 @@ import org.fossasia.susi.ai.dataclasses.SkillMetricsDataQuery
 import org.fossasia.susi.ai.dataclasses.SkillsBasedOnMetrics
 import org.fossasia.susi.ai.helper.Constant
 import org.fossasia.susi.ai.helper.PrefManager
-import org.fossasia.susi.ai.rest.responses.susi.Metrics
 import org.fossasia.susi.ai.rest.responses.susi.ListGroupsResponse
 import org.fossasia.susi.ai.rest.responses.susi.ListSkillMetricsResponse
 import org.fossasia.susi.ai.rest.responses.susi.ListSkillsResponse
+import org.fossasia.susi.ai.rest.responses.susi.Metrics
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
 import org.fossasia.susi.ai.skills.skilllisting.contract.ISkillListingPresenter
 import org.fossasia.susi.ai.skills.skilllisting.contract.ISkillListingView
@@ -25,6 +26,13 @@ import timber.log.Timber
  */
 class SkillListingPresenter(val skillListingFragment: SkillListingFragment) : ISkillListingPresenter, ISkillListingModel.OnFetchGroupsFinishedListener,
         ISkillListingModel.OnFetchSkillsFinishedListener, ISkillListingModel.OnFetchSkillMetricsFinishedListener {
+    companion object {
+        val showMenuIcon: MutableLiveData<Boolean> = MutableLiveData()
+    }
+
+    val a: Int = 0
+    var c: Int = 0
+    var b: Int = 0
 
     private var skillListingModel: ISkillListingModel = SkillListingModel()
     private var skillListingView: ISkillListingView? = null
@@ -55,6 +63,8 @@ class SkillListingPresenter(val skillListingFragment: SkillListingFragment) : IS
         if (response.isSuccessful && groupsResponse != null) {
             Timber.d("GROUPS FETCHED")
             groupsCount = groupsResponse.groups.size
+
+            b = groupsCount
             metrics.groups = groupsResponse.groups as MutableList<String>
             skillListingView?.updateAdapter(metrics)
             skillListingModel.fetchSkills(metrics.groups[0], PrefManager.getString(Constant.LANGUAGE, Constant.DEFAULT), this)
@@ -75,6 +85,10 @@ class SkillListingPresenter(val skillListingFragment: SkillListingFragment) : IS
         skillListingView?.visibilityProgressBar(false)
         if (response.isSuccessful && skillsResponse != null) {
             Timber.d("SKILLS FETCHED")
+            if (c == 0 || c != b) c++
+            if (c != 0 && c == b && showMenuIcon.value != true) showMenuIcon.value = true
+
+            Timber.d("c $c b $b")
             val responseSkillMap = skillsResponse.filteredSkillsData
             if (responseSkillMap.isNotEmpty()) {
                 skills.add(Pair(group, responseSkillMap))

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
@@ -2,25 +2,56 @@ package org.fossasia.susi.ai.skills.skilllisting.adapters.recycleradapters
 
 import android.content.Context
 import android.support.annotation.NonNull
-import android.support.v7.widget.RecyclerView
+import android.support.v7.recyclerview.extensions.ListAdapter
+import android.support.v7.util.DiffUtil
 import android.text.TextUtils
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.helper.Utils
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
 import org.fossasia.susi.ai.skills.SkillFragmentCallback
 import org.fossasia.susi.ai.skills.skilllisting.adapters.viewholders.SkillViewHolder
+import timber.log.Timber
 
-class SkillListAdapter(val context: Context, private val skillDetails: List<SkillData>?, val skillCallback: SkillFragmentCallback) : RecyclerView.Adapter<SkillViewHolder>(),
+
+/**
+ * adapter to show individual skill
+ */
+class SkillListAdapter(val context: Context, skillDetails: List<SkillData>?, val skillCallback: SkillFragmentCallback, val search: Boolean = false)
+    : ListAdapter<SkillData, SkillViewHolder>(DIFF_CALLBACK),
         SkillViewHolder.ClickListener {
+    companion object {
+        val DIFF_CALLBACK = object : DiffUtil.ItemCallback<SkillData>() {
+            override fun areItemsTheSame(p0: SkillData, p1: SkillData): Boolean {
+                return true
+            }
+
+            override fun areContentsTheSame(p0: SkillData, p1: SkillData): Boolean {
+                return p0 == p1
+            }
+        }
+    }
+
+    private var list: List<SkillData>? = skillDetails
+
+    /**
+     * @param skillList updates the list variable
+     */
+    fun setSkillList(skillList: List<SkillData>) {
+        list = skillList
+    }
 
     private val clickListener: SkillViewHolder.ClickListener = this
 
     @NonNull
     override fun onBindViewHolder(holder: SkillViewHolder, position: Int) {
-        if (skillDetails != null) {
-            val skillData = skillDetails.toTypedArray()[position]
+        val skillData: SkillData
+
+        if (list != null) {
+
+            skillData = getItem(position)
 
             if (TextUtils.isEmpty(skillData.skillName)) {
                 holder.skillPreviewTitle.text = context.getString(R.string.no_skill_name)
@@ -48,14 +79,12 @@ class SkillListAdapter(val context: Context, private val skillDetails: List<Skil
         }
     }
 
-    override fun getItemCount(): Int {
-        return (skillDetails as List<SkillData>).size
-    }
-
     override fun onItemClicked(position: Int) {
-        val skillTag = skillDetails?.toTypedArray()?.get(position)?.skillTag ?: ""
-        val skillData = skillDetails?.get(position)
-        val skillGroup = skillDetails?.get(position)?.group?.replace(" ", "%20")
+        Timber.d("onItemClicked $position")
+        val skillTag: String = getItem(position)?.skillTag ?: ""
+
+        val skillData = list?.get(position)
+        val skillGroup = list?.get(position)?.group?.replace(" ", "%20")
         showSkillDetailFragment(skillData, skillGroup, skillTag)
     }
 
@@ -65,8 +94,13 @@ class SkillListAdapter(val context: Context, private val skillDetails: List<Skil
 
     @NonNull
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SkillViewHolder {
-        val itemView = LayoutInflater.from(parent.context)
-                .inflate(R.layout.item_skill, parent, false)
+        val itemView: View = when (search) {
+            true -> LayoutInflater.from(parent.context)
+                    .inflate(R.layout.item_skills, parent, false)
+            else -> LayoutInflater.from(parent.context)
+                    .inflate(R.layout.item_skill, parent, false)
+        }
+
         return SkillViewHolder(itemView, clickListener)
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillListAdapter.kt
@@ -15,7 +15,6 @@ import org.fossasia.susi.ai.skills.SkillFragmentCallback
 import org.fossasia.susi.ai.skills.skilllisting.adapters.viewholders.SkillViewHolder
 import timber.log.Timber
 
-
 /**
  * adapter to show individual skill
  */

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillMetricsAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/adapters/recycleradapters/SkillMetricsAdapter.kt
@@ -36,7 +36,9 @@ class SkillMetricsAdapter(val context: Context, val metrics: SkillsBasedOnMetric
             holder.skillList.setHasFixedSize(true)
             val layoutManager = LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
             holder.skillList.layoutManager = layoutManager
-            holder.skillList.adapter = SkillListAdapter(context, metrics.metricsList[position], skillCallback)
+            val skillListAdapter = SkillListAdapter(context, metrics.metricsList[position], skillCallback)
+            holder.skillList.adapter = skillListAdapter
+            skillListAdapter.submitList(metrics.metricsList[position])
             holder.skillList.onFlingListener = null
             skillAdapterSnapHelper.attachToRecyclerView(holder.skillList)
         }

--- a/app/src/main/res/animator/custom_fade_in.xml
+++ b/app/src/main/res/animator/custom_fade_in.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <objectAnimator
+        android:duration="120"
+        android:interpolator="@android:interpolator/accelerate_decelerate"
+        android:propertyName="alpha"
+        android:valueFrom="0.0f"
+        android:valueTo="1.0f"/>
+</set>

--- a/app/src/main/res/animator/custom_fade_out.xml
+++ b/app/src/main/res/animator/custom_fade_out.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android">
+    <objectAnimator
+        android:duration="120"
+        android:interpolator="@android:interpolator/accelerate_decelerate"
+        android:propertyName="alpha"
+        android:valueFrom="1.0f"
+        android:valueTo="0.0f"/>
+</set>

--- a/app/src/main/res/layout/activity_skills.xml
+++ b/app/src/main/res/layout/activity_skills.xml
@@ -1,9 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 
+
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/fragment_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/default_bg">
+    android:orientation="vertical">
 
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="@color/default_bg" />
 </FrameLayout>

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -1,30 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
+
+<android.support.v7.widget.RecyclerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/items_list"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
-
-    <LinearLayout
-        android:id="@+id/list_panel"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="?android:attr/windowBackground"
-        android:focusable="true"
-        android:focusableInTouchMode="true"
-        android:visibility="gone"
-        tools:background="@android:color/transparent"
-        tools:visibility="visible">
-
-        <android.support.v7.widget.RecyclerView
-            android:id="@+id/items_list"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
-            android:scrollbars="vertical"
-            tools:listitem="@layout/item_skills" />
-
-    </LinearLayout>
+    android:layout_height="match_parent"
+    android:background="?android:attr/windowBackground"
+    android:focusable="true"
+    android:focusableInTouchMode="true"
+    android:scrollbars="vertical"
+    android:visibility="gone"
+    tools:background="@android:color/transparent"
+    tools:listitem="@layout/item_skills"
+    tools:visibility="visible" />
 
 
 
-</RelativeLayout>
+

--- a/app/src/main/res/layout/fragment_search.xml
+++ b/app/src/main/res/layout/fragment_search.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:id="@+id/list_panel"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:background="?android:attr/windowBackground"
+        android:focusable="true"
+        android:focusableInTouchMode="true"
+        android:visibility="gone"
+        tools:background="@android:color/transparent"
+        tools:visibility="visible">
+
+        <android.support.v7.widget.RecyclerView
+            android:id="@+id/items_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:scrollbars="vertical"
+            tools:listitem="@layout/item_skills" />
+
+    </LinearLayout>
+
+
+
+</RelativeLayout>

--- a/app/src/main/res/layout/fragment_skill_listing.xml
+++ b/app/src/main/res/layout/fragment_skill_listing.xml
@@ -1,35 +1,77 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/swipe_refresh_layout"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
 
-    <FrameLayout
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:background="@color/default_bg">
 
+        <!--items_list-->
         <android.support.v7.widget.RecyclerView
             android:id="@+id/skillMetrics"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            android:scrollbars="vertical"
+            app:layoutManager="LinearLayoutManager" />
 
+        <!--loading_progress_bar-->
         <ProgressBar
             android:id="@+id/progressSkillWait"
-            android:layout_width="@dimen/progress_bar_size"
-            android:layout_height="@dimen/progress_bar_size"
-            android:layout_gravity="center" />
-
-        <TextView
-            android:id="@+id/errorSkillFetch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center_horizontal"
-            android:padding="@dimen/padding_large"
-            android:text="@string/error_skill_listing"
-            android:textColor="@color/colorPrimary"
-            android:textSize="@dimen/text_size_large"
-            android:visibility="gone" />
-    </FrameLayout>
+            android:layout_centerInParent="true"
+            android:indeterminate="true"
+            android:visibility="gone"
+            tools:visibility="visible" />
+
+        <LinearLayout
+            android:id="@+id/empty_state_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_centerInParent="true"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:layout_marginBottom="10dp"
+                android:fontFamily="monospace"
+                android:text="╰(°●°╰)"
+                android:textSize="35sp"
+                tools:ignore="HardcodedText,UnusedAttribute" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/search_no_results"
+                android:textSize="24sp" />
+        </LinearLayout>
+
+
+        <TextView
+        android:id="@+id/errorSkillFetch"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerHorizontal="true"
+        android:layout_gravity="center"
+        android:layout_marginTop="50dp"
+        android:gravity="center_horizontal"
+        android:padding="@dimen/padding_large"
+        android:text="@string/error_skill_listing"
+        android:textColor="@color/colorPrimary"
+        android:textSize="@dimen/text_size_large"
+        android:visibility="gone"
+        tools:visibility="visible" />
+    </RelativeLayout>
+
+
 </android.support.v4.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/item_skills.xml
+++ b/app/src/main/res/layout/item_skills.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginTop="@dimen/margin_very_small">
+
+    <android.support.v7.widget.CardView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="@dimen/margin_small"
+        android:layout_marginLeft="@dimen/margin_small"
+        android:layout_marginTop="@dimen/margin_small"
+        android:layout_marginBottom="@dimen/margin_small"
+        android:foreground="?attr/selectableItemBackground"
+        app:cardBackgroundColor="@color/susi_message_bg"
+        app:cardCornerRadius="@dimen/radius_skill_card_corner"
+        app:cardUseCompatPadding="true">
+
+        <LinearLayout
+            android:id="@+id/preview_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:background="@color/default_bg"
+            android:orientation="vertical">
+
+            <LinearLayout
+                android:id="@+id/link_preview_text_layout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/margin_small"
+                android:background="@color/md_white_1000"
+                android:orientation="horizontal"
+                android:padding="@dimen/padding_moderate">
+
+                <ImageView
+                    android:id="@+id/skill_preview_image"
+                    android:layout_width="@dimen/skill_image_size"
+                    android:layout_height="@dimen/skill_image_size"
+                    android:adjustViewBounds="true"
+                    android:background="@color/md_white_1000"
+                    android:padding="@dimen/margin_small"
+                    android:scaleType="centerInside"
+                    app:srcCompat="@drawable/ic_user" />
+
+                <TextView
+                    android:id="@+id/skill_preview_example"
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/skill_image_size"
+                    android:layout_gravity="center"
+                    android:layout_weight="1"
+                    android:background="@color/md_white_1000"
+                    android:fontFamily="sans-serif"
+                    android:gravity="center"
+                    android:maxLines="3"
+                    android:padding="@dimen/padding_small"
+                    android:textAlignment="center"
+                    android:textColor="@color/md_grey_700"
+                    android:textSize="@dimen/text_size_normal"
+                    android:textStyle="italic"
+                    tools:text="@string/sample_website_description" />
+            </LinearLayout>
+
+            <TextView
+                android:id="@+id/skill_preview_title"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@color/default_bg"
+                android:ellipsize="end"
+                android:fontFamily="sans-serif"
+                android:maxLines="1"
+                android:paddingLeft="@dimen/cmv_padding"
+                android:paddingTop="@dimen/padding_small"
+                android:paddingRight="@dimen/cmv_padding"
+                android:text="@string/skill_title"
+                android:textColor="@color/colorPrimary"
+                android:textSize="@dimen/text_size_moderate" />
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+
+                <RatingBar
+                    android:id="@+id/cv_rating_bar"
+                    style="?android:attr/ratingBarStyleSmall"
+                    android:layout_width="@dimen/rating_bar_layout_width"
+                    android:layout_height="wrap_content"
+                    android:numStars="5"
+                    android:padding="@dimen/cmv_padding"
+                    android:theme="@style/RatingBar" />
+
+                <TextView
+                    android:id="@+id/cv_total_ratings"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="@dimen/cmv_padding"
+                    android:paddingBottom="@dimen/cmv_padding"
+                    android:text="@string/digit_zero"
+                    android:textColor="@color/colorPrimary" />
+
+            </LinearLayout>
+        </LinearLayout>
+
+    </android.support.v7.widget.CardView>
+</LinearLayout>

--- a/app/src/main/res/layout/search_bar.xml
+++ b/app/src/main/res/layout/search_bar.xml
@@ -2,6 +2,7 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:id="@+id/toolbar_search_container"
     android:orientation="horizontal">
 
     <EditText

--- a/app/src/main/res/menu/skills_activity_menu.xml
+++ b/app/src/main/res/menu/skills_activity_menu.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <group
-        android:id="@+id/menu_items">
+    <group android:id="@+id/menu_items">
         <item
             android:id="@+id/menu_settings"
             android:icon="@drawable/ic_settings_24dp"
@@ -11,10 +10,15 @@
             android:id="@+id/menu_about"
             android:icon="@drawable/ic_about"
             android:title="@string/menu_item_about" />
+
+
         <item
             android:id="@+id/action_search"
             android:icon="@drawable/ic_open_search"
+            android:orderInCategory="100"
             android:title="@string/search"
-            app:showAsAction="ifRoom" />
+            app:showAsAction="always" />
+
+
     </group>
 </menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -199,4 +199,7 @@
     <string name="no_device_found">Keine Geräte gefunden</string>
     <string name="setup_tut">Wenn Sie ein neues Gerät einrichten, stellen Sie sicher, dass es ist  in der Nähe und an eine Steckdose angeschlossen</string>
     <string name="no_wifi_found">Keine WiFi-Netzwerke gefunden</string>
+
+
+
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -431,4 +431,14 @@
     <string name="report_send_success">Skill reported successfully</string>
     <string name="reported_already">Skill already reported</string>
 
+
+    <string name="show_search_suggestions_key" translatable="false">show_search_suggestions</string>
+    <string name="content_country_key" translatable="false">content_country</string>
+    <string name="default_country_value">GB</string>
+    <string name="enable_search_history_key" translatable="false">enable_search_history</string>
+    <string name="list_view_mode_key" translatable="false">list_view_mode</string>
+    <string name="search_no_results">No results</string>
+    <string name="clear">Clear</string>
+
+
 </resources>

--- a/app/src/playStore/java/org/fossasia/susi/ai/chat/YouTubeActivity.kt
+++ b/app/src/playStore/java/org/fossasia/susi/ai/chat/YouTubeActivity.kt
@@ -15,7 +15,7 @@ import timber.log.Timber
 
 /**
  *
- * This activity plays youtube video in the app, the video ID is received from the server.
+ * This appActivity plays youtube video in the app, the video ID is received from the server.
  *
  * Created by batbrain7 on 16/06/2018
  *


### PR DESCRIPTION
Fixes #1800 and #1902 

Changes: 
The search icon remains hidden until all the skills are
retrieved and then shown when the retrieval is complete.
ListAdapter is used to display search results for proper
model diffing.

Screenshots for the change: 
### Search is not visible until all the network requests are fetched.
<img src="https://user-images.githubusercontent.com/29420591/53833812-736f2000-3faf-11e9-8e47-d7e0fffb861e.png" width="30%"></img> 
## Search icon is visible and can perform searching when the requests are done.
<img src="https://user-images.githubusercontent.com/29420591/53833828-7d911e80-3faf-11e9-8d6f-8f16464c7457.png" width="30%"></img> 



