### PR TITLE
Feature : Added padding in skill listing fragment

### DIFF
--- a/app/src/main/res/layout/fragment_skill_listing.xml
+++ b/app/src/main/res/layout/fragment_skill_listing.xml
@@ -12,7 +12,8 @@
         <android.support.v7.widget.RecyclerView
             android:id="@+id/skillMetrics"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
+            android:layout_height="match_parent"
+            android:padding="8dp"/>
 
         <ProgressBar
             android:id="@+id/progressSkillWait"


### PR DESCRIPTION
Fixes #1999 
Currently i have given it a padding of 8dp, it can be changed as per your requirement.

Changes:added padding of 8dp in recycler view of fragment_skill_listing file. 

Screenshots for the change: 
![Screenshot_20190309_205816](https://user-images.githubusercontent.com/42909612/54073557-a581ca00-42ae-11e9-8c57-8dd2cc8d2e2f.jpg)
