### PR TITLE
fix: Hyperlinked words instead of entire textview

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -1,12 +1,10 @@
 package org.fossasia.susi.ai.skills.aboutus
 
 import android.net.Uri
-import android.os.Build
 import android.os.Bundle
 import android.support.annotation.NonNull
 import android.support.customtabs.CustomTabsIntent
 import android.support.v4.app.Fragment
-import android.text.Html
 import android.text.SpannableString
 import android.text.Spanned
 import android.text.method.LinkMovementMethod
@@ -14,7 +12,6 @@ import android.text.style.ClickableSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.TextView
 import android.widget.Toast
 import kotlinx.android.synthetic.*
 import kotlinx.android.synthetic.main.fragment_about_us.about_susi
@@ -29,9 +26,9 @@ class AboutUsFragment : Fragment() {
 
     @NonNull
     override fun onCreateView(
-            inflater: LayoutInflater,
-            container: ViewGroup?,
-            savedInstanceState: Bundle?
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
     ): View? {
         val thisActivity = activity
         if (thisActivity is SkillsActivity) thisActivity.title = getString(R.string.action_about_us)

--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -47,7 +47,7 @@ class AboutUsFragment : Fragment() {
         val clickableSpan=object : ClickableSpan(){
             override fun onClick(textView: View) {
                 val uri = Uri.parse(getString(R.string.url_about_susi))
-                   launchCustomtTab(uri)
+                launchCustomtTab(uri)
             }
         }
         aboutUsString.setSpan(clickableSpan, 0, 7 , Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
@@ -90,7 +90,6 @@ class AboutUsFragment : Fragment() {
         susi_license_info_desc.text = licenseString
         susi_license_info_desc.movementMethod = LinkMovementMethod.getInstance()
 
-
         //SUSI report info description
         val reportString = SpannableString(susi_report_issues_desc.text)
         val reportSpan=object : ClickableSpan(){
@@ -102,7 +101,6 @@ class AboutUsFragment : Fragment() {
         reportString.setSpan(reportSpan, 32, 63 , Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         susi_report_issues_desc.text = reportString
         susi_report_issues_desc.movementMethod = LinkMovementMethod.getInstance()
-
 
         super.onViewCreated(view, savedInstanceState)
     }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -29,9 +29,9 @@ class AboutUsFragment : Fragment() {
 
     @NonNull
     override fun onCreateView(
-        inflater: LayoutInflater,
-        container: ViewGroup?,
-        savedInstanceState: Bundle?
+            inflater: LayoutInflater,
+            container: ViewGroup?,
+            savedInstanceState: Bundle?
     ): View? {
         val thisActivity = activity
         if (thisActivity is SkillsActivity) thisActivity.title = getString(R.string.action_about_us)
@@ -44,61 +44,61 @@ class AboutUsFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         //aboutUs textview got spanned
         val aboutUsString = SpannableString(about_susi.text)
-        val clickableSpan=object : ClickableSpan(){
+        val clickableSpan = object : ClickableSpan() {
             override fun onClick(textView: View) {
                 val uri = Uri.parse(getString(R.string.url_about_susi))
                 launchCustomtTab(uri)
             }
         }
-        aboutUsString.setSpan(clickableSpan, 0, 7 , Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        aboutUsString.setSpan(clickableSpan, 0, 7, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         about_susi.text = aboutUsString
         about_susi.movementMethod = LinkMovementMethod.getInstance()
 
         //Contributors
         val contributorsString = SpannableString(contributors_desc.text)
-        val contributorsSpan=object : ClickableSpan(){
+        val contributorsSpan = object : ClickableSpan() {
             override fun onClick(textView: View) {
                 val uri = Uri.parse(getString(R.string.url_susi_contributors))
                 launchCustomtTab(uri)
             }
         }
-        contributorsString.setSpan(contributorsSpan, 13, 25 , Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        contributorsString.setSpan(contributorsSpan, 13, 25, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         contributors_desc.text = contributorsString
         contributors_desc.movementMethod = LinkMovementMethod.getInstance()
 
         //SUSI_SKILLS_CMS_DESC
         val skillsString = SpannableString(susi_skill_cms_desc.text)
-        val skillsSpan=object : ClickableSpan(){
+        val skillsSpan = object : ClickableSpan() {
             override fun onClick(textView: View) {
                 val uri = Uri.parse(getString(R.string.url_susi_skill_cms))
                 launchCustomtTab(uri)
             }
         }
-        skillsString.setSpan(skillsSpan, 71, 86 , Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        skillsString.setSpan(skillsSpan, 71, 86, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         susi_skill_cms_desc.text = skillsString
         susi_skill_cms_desc.movementMethod = LinkMovementMethod.getInstance()
 
         //SUSI license info description
         val licenseString = SpannableString(susi_license_info_desc.text)
-        val licenseSpan=object : ClickableSpan(){
+        val licenseSpan = object : ClickableSpan() {
             override fun onClick(textView: View) {
                 val uri = Uri.parse(getString(R.string.url_susi_license))
                 launchCustomtTab(uri)
             }
         }
-        licenseString.setSpan(licenseSpan, 83, 94 , Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        licenseString.setSpan(licenseSpan, 83, 94, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         susi_license_info_desc.text = licenseString
         susi_license_info_desc.movementMethod = LinkMovementMethod.getInstance()
 
         //SUSI report info description
         val reportString = SpannableString(susi_report_issues_desc.text)
-        val reportSpan=object : ClickableSpan(){
+        val reportSpan = object : ClickableSpan() {
             override fun onClick(textView: View) {
                 val uri = Uri.parse(getString(R.string.url_susi_report_issue))
                 launchCustomtTab(uri)
             }
         }
-        reportString.setSpan(reportSpan, 32, 63 , Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        reportString.setSpan(reportSpan, 32, 63, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
         susi_report_issues_desc.text = reportString
         susi_report_issues_desc.movementMethod = LinkMovementMethod.getInstance()
 
@@ -110,13 +110,6 @@ class AboutUsFragment : Fragment() {
             CustomTabsIntent.Builder().build().launchUrl(context, uri) //launching through custom tabs
         } catch (e: Exception) {
             Toast.makeText(context, getString(R.string.link_unavailable), Toast.LENGTH_SHORT).show()
-        }
-    }
-
-    private fun htmlConverter(resourceId: Int): Spanned {
-        return when {
-            Build.VERSION.SDK_INT>24 -> Html.fromHtml(getString(resourceId), Html.FROM_HTML_OPTION_USE_CSS_COLORS)
-            else -> @Suppress("DEPRECATION") Html.fromHtml(getString(resourceId))
         }
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -7,11 +7,16 @@ import android.support.annotation.NonNull
 import android.support.customtabs.CustomTabsIntent
 import android.support.v4.app.Fragment
 import android.text.Html
+import android.text.SpannableString
 import android.text.Spanned
+import android.text.method.LinkMovementMethod
+import android.text.style.ClickableSpan
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.TextView
 import android.widget.Toast
+import kotlinx.android.synthetic.*
 import kotlinx.android.synthetic.main.fragment_about_us.about_susi
 import kotlinx.android.synthetic.main.fragment_about_us.contributors_desc
 import kotlinx.android.synthetic.main.fragment_about_us.susi_skill_cms_desc
@@ -37,35 +42,67 @@ class AboutUsFragment : Fragment() {
 
     @NonNull
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        about_susi.setOnClickListener {
-            val uri = Uri.parse(getString(R.string.url_about_susi))
-            launchCustomtTab(uri)
+        //aboutUs textview got spanned
+        val aboutUsString = SpannableString(about_susi.text)
+        val clickableSpan=object : ClickableSpan(){
+            override fun onClick(textView: View) {
+                val uri = Uri.parse(getString(R.string.url_about_susi))
+                   launchCustomtTab(uri)
+            }
         }
+        aboutUsString.setSpan(clickableSpan, 0, 7 , Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        about_susi.text = aboutUsString
+        about_susi.movementMethod = LinkMovementMethod.getInstance()
 
-        contributors_desc.setOnClickListener {
-            val uri = Uri.parse(getString(R.string.url_susi_contributors))
-            launchCustomtTab(uri)
+        //Contributors
+        val contributorsString = SpannableString(contributors_desc.text)
+        val contributorsSpan=object : ClickableSpan(){
+            override fun onClick(textView: View) {
+                val uri = Uri.parse(getString(R.string.url_susi_contributors))
+                launchCustomtTab(uri)
+            }
         }
+        contributorsString.setSpan(contributorsSpan, 13, 25 , Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        contributors_desc.text = contributorsString
+        contributors_desc.movementMethod = LinkMovementMethod.getInstance()
 
-        susi_skill_cms_desc.setOnClickListener {
-            val uri = Uri.parse(getString(R.string.url_susi_skill_cms))
-            launchCustomtTab(uri)
+        //SUSI_SKILLS_CMS_DESC
+        val skillsString = SpannableString(susi_skill_cms_desc.text)
+        val skillsSpan=object : ClickableSpan(){
+            override fun onClick(textView: View) {
+                val uri = Uri.parse(getString(R.string.url_susi_skill_cms))
+                launchCustomtTab(uri)
+            }
         }
+        skillsString.setSpan(skillsSpan, 71, 86 , Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        susi_skill_cms_desc.text = skillsString
+        susi_skill_cms_desc.movementMethod = LinkMovementMethod.getInstance()
 
-        susi_report_issues_desc.setOnClickListener {
-            val uri = Uri.parse(getString(R.string.url_susi_report_issue))
-            launchCustomtTab(uri)
+        //SUSI license info description
+        val licenseString = SpannableString(susi_license_info_desc.text)
+        val licenseSpan=object : ClickableSpan(){
+            override fun onClick(textView: View) {
+                val uri = Uri.parse(getString(R.string.url_susi_license))
+                launchCustomtTab(uri)
+            }
         }
-        susi_license_info_desc.setOnClickListener {
-            val uri = Uri.parse(getString(R.string.url_susi_license))
-            launchCustomtTab(uri)
-        }
+        licenseString.setSpan(licenseSpan, 83, 94 , Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        susi_license_info_desc.text = licenseString
+        susi_license_info_desc.movementMethod = LinkMovementMethod.getInstance()
 
-        about_susi.text = htmlConverter(R.string.susi_about)
-        contributors_desc.text = htmlConverter(R.string.susi_contributors_desc)
-        susi_skill_cms_desc.text = htmlConverter(R.string.susi_skill_cms_desc)
-        susi_license_info_desc.text = htmlConverter(R.string.susi_license_information_desc)
-        susi_report_issues_desc.text = htmlConverter(R.string.susi_report_issues_desc)
+
+        //SUSI report info description
+        val reportString = SpannableString(susi_report_issues_desc.text)
+        val reportSpan=object : ClickableSpan(){
+            override fun onClick(textView: View) {
+                val uri = Uri.parse(getString(R.string.url_susi_report_issue))
+                launchCustomtTab(uri)
+            }
+        }
+        reportString.setSpan(reportSpan, 32, 63 , Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
+        susi_report_issues_desc.text = reportString
+        susi_report_issues_desc.movementMethod = LinkMovementMethod.getInstance()
+
 
         super.onViewCreated(view, savedInstanceState)
     }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -13,7 +13,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
-import kotlinx.android.synthetic.*
 import kotlinx.android.synthetic.main.fragment_about_us.about_susi
 import kotlinx.android.synthetic.main.fragment_about_us.contributors_desc
 import kotlinx.android.synthetic.main.fragment_about_us.susi_skill_cms_desc

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -284,22 +284,19 @@
 
     <!--About Us String-->
     <string name="url_about_susi" translatable="false">https://chat.susi.ai/overview</string>
-    <string name="susi_about">
-        <a href="https://chat.susi.ai/overview"><![CDATA[<u><font color='#4184f3'>SUSI.AI</u></font>]]></a> is an intelligent libre software personal assistant. It is capable of chat and voice interaction by using APIs to perform actions such as music playback, making to-do lists, setting alarms, streaming podcasts, playing audiobooks, and providing weather, traffic, and other real time information. Additional functionalities can be added as console services using external APIs. SUSI.AI is able to answer questions and depending on the context will ask for additional information in order to perform the desired outcome. The core of the assistant is the SUSI.AI server that holds the "intelligence" and "personality" of SUSI.AI.</string>
+    <string name="susi_about">SUSI.AI is an intelligent libre software personal assistant. It is capable of chat and voice interaction by using APIs to perform actions such as music playback, making to-do lists, setting alarms, streaming podcasts, playing audiobooks, and providing weather, traffic, and other real time information. Additional functionalities can be added as console services using external APIs. SUSI.AI is able to answer questions and depending on the context will ask for additional information in order to perform the desired outcome. The core of the assistant is the SUSI.AI server that holds the "intelligence" and "personality" of SUSI.AI.</string>
     <string name="susi_contributors">Contributors</string>
     <string name="url_susi_contributors" translatable="false">https://github.com/fossasia/susi_android/graphs/contributors</string>
-    <string name="susi_contributors_desc">Developed by <a href="https://github.com/fossasia/susi_android/graphs/contributors"><![CDATA[<u><font color='#4184f3'>Contributors</u></font>]]></a>.</string>
+    <string name="susi_contributors_desc">Developed by Contributors.</string>
     <string name="susi_license_information">License</string>
     <string name="url_susi_license" translatable="false">https://github.com/fossasia/susi_android/blob/master/LICENSE</string>
-    <string name="susi_license_information_desc">This project is currently licensed under the Apache License Version 2.0. As per the <a href="https://github.com/fossasia/susi_android/blob/master/LICENSE"><![CDATA[<u><font color='#4184f3'>LICENSE.md</u></font>]]></a>
-    </string>
+    <string name="susi_license_information_desc">This project is currently licensed under the Apache License Version 2.0. As per the LICENSE.md.</string>
     <string name="susi_report_issues">Report Issues</string>
     <string name="url_susi_report_issue" translatable="false">https://github.com/fossasia/susi_android/issues</string>
-    <string name="susi_report_issues_desc">Please report all the issues in <a href="https://github.com/fossasia/susi_android/issues"><![CDATA[<u><font color='#4184f3'>Github Repository Issue Tracker</u></font>]]></a>.</string>
-
+    <string name="susi_report_issues_desc">Please report all the issues in Github Repository Issue Tracker.</string>
     <string name="susi_skill_cms">SUSI Skill CMS</string>
     <string name="url_susi_skill_cms">https://skills.susi.ai</string>
-    <string name="susi_skill_cms_desc">SUSI is having many skills. You can look at the collection of skills at <a href="http://www.skills.susi.ai"><![CDATA[<u><font color='#4184f3'>skills.susi.ai</u></font>]]></a>. SUSI Skill development is easy and fun. You can edit existing skills or even create your own.</string>
+    <string name="susi_skill_cms_desc">SUSI is having many skills. You can look at the collection of skills at skills.susi.ai. SUSI Skill development is easy and fun. You can edit existing skills or even create your own.</string>
 
     <!-- Intro Strings -->
     <string name="author_name">Author name</string>


### PR DESCRIPTION
Fixes #1955 

Changes: 
Replaced the older techniques used by using Span in AboutUsFragment
Modified the string file.

Screenshots for the change: 
![clickable_word](https://user-images.githubusercontent.com/43731599/54077159-c4965100-42da-11e9-87ce-a892f616d4ae.gif)
