### PR TITLE
circle ci migration

### DIFF
--- a/.circleci/ci-setup.sh
+++ b/.circleci/ci-setup.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# Accept licenses
+${ANDROID_HOME}/tools/bin/sdkmanager --licenses
+
+# Install dependencies
+./gradlew androidDependencies || true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,103 @@
+version: 2.0
+
+references:
+
+  workspace_root: &workspace_root
+                    ~/workspace
+
+  container_config: &container_config
+    docker:
+    - image: circleci/android:api-28
+
+    working_directory: *workspace_root
+
+    environment:
+      TERM: dumb
+      JVM_OPTS: -Xmx4096m
+
+  attach_workspace: &attach_workspace
+    attach_workspace:
+      at: *workspace_root
+
+  general_cache_key: &general_cache_key
+    key: app-{{ checksum "build.gradle.kts" }}-{{ checksum "app/build.gradle.kts" }}-{{ checksum ".circleci/config.yml" }}-{{ checksum "gradle.properties" }}-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}
+
+jobs:
+
+  build:
+    <<: *container_config
+    steps:
+    - checkout
+
+    - restore_cache:
+        <<: *general_cache_key
+    - run:
+        name: Setup environment
+        command: scripts/ci-setup.sh
+    - save_cache:
+        <<: *general_cache_key
+        paths:
+        - "~/.gradle"
+        - "~/.m2"
+        - "/opt/android-sdk-linux/licenses/"
+
+    - run:
+        name: Build
+        command: ./gradlew assembleDebug
+
+    - store_artifacts:
+        path: app/build/outputs/apk/
+        destination: apks/
+
+    - persist_to_workspace:
+        root: *workspace_root
+        paths:
+        - .
+
+  check:
+    <<: *container_config
+    steps:
+    - *attach_workspace
+
+    - restore_cache:
+        <<: *general_cache_key
+
+    - run:
+        name: Run checks
+        command: ./gradlew lintDebug ktlintCheck
+
+    - store_artifacts:
+        path: app/build/reports/
+        destination: lint_reports/app/
+
+  test:
+    <<: *container_config
+    steps:
+    - *attach_workspace
+
+    - restore_cache:
+        <<: *general_cache_key
+
+    - run:
+        name: Run tests
+        command: ./gradlew testDebugUnitTest
+
+    - store_artifacts:
+        path: app/build/reports/tests/
+        destination: tests_reports/
+
+    - store_test_results:
+        path: app/build/test-results
+
+workflows:
+  version: 2
+
+  build_check_tests:
+    jobs:
+    - build
+    - check:
+        requires:
+        - build
+    - test:
+        requires:
+        - build


### PR DESCRIPTION
Fixes #1975 
Changes: Tried to migrate circleci into 2.0 by creating another branch and modifying the config.yml code according to the new 2.0 congiration and also a setup.sh file for gradle errors

