### PR TITLE
fix: Title change to settings on moving back from about us

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -247,6 +247,11 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
         }
     }
 
+    override fun onResume() {
+        val thisActivity = activity
+        if (thisActivity is SkillsActivity) thisActivity.title = getString(R.string.action_settings)
+        super.onResume()
+    }
     private fun setLanguage() {
         try {
             if (querylanguage.entries.isNotEmpty()) {


### PR DESCRIPTION
Fixes #2050 
Changes:chat settings fragment

Screenshots for the change: 
![Screenrecording_20190322_024111](https://user-images.githubusercontent.com/42909612/54785599-a4f11800-4c4c-11e9-8a66-3207cfff8fd1.gif)
