### PR TITLE
fix: name of skill now showing in groupwise skills

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/recycleradapters/SkillsListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/recycleradapters/SkillsListAdapter.kt
@@ -31,7 +31,7 @@ class SkillsListAdapter(
     override fun onBindViewHolder(holder: SkillViewHolder, position: Int) {
         val skillData = skillDetails.skillsList.get(position)
 
-        if (skillData.skillName.isNotEmpty()) {
+        if (skillData.skillName.isEmpty()) {
             holder.skillName.text = context.getString(R.string.no_skill_name)
         } else {
             holder.skillName.text = skillData.skillName


### PR DESCRIPTION
Fixes #2069 s #IssueNumber]

Changes: Name of skill is shown now in GroupWise skills

Screenshots for the change: 
![Screenshot_2019-03-24-23-08-34](https://user-images.githubusercontent.com/31595908/54883413-cd1a8a00-4e8b-11e9-8417-449286421cba.png)
