### PR TITLE
fix: Placeholder values of author name and example is not showing now in GroupWise Skills

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/recycleradapters/SkillsListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/recycleradapters/SkillsListAdapter.kt
@@ -37,13 +37,13 @@ class SkillsListAdapter(
             holder.skillName.text = skillData.skillName
         }
 
-        if (skillData.author.isEmpty()) {
+        if (skillData.author.isEmpty() || skillData.author.equals(context.getString(R.string.default_author_name))) {
             holder.skillAuthorName.text = context.getString(R.string.no_skill_author)
         } else {
             holder.skillAuthorName.text = skillData.author
         }
 
-        if (skillData.examples.isEmpty())
+        if (skillData.examples.isEmpty() || skillData.examples.contains(context.getString(R.string.default_example)))
             holder.skillExample.text = ""
         else
             holder.skillExample.text = StringBuilder("\"").append(skillData.examples[0]).append("\"")

--- a/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/recycleradapters/SkillsListAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/groupwiseskills/adapters/recycleradapters/SkillsListAdapter.kt
@@ -24,6 +24,8 @@ class SkillsListAdapter(
 ) :
         RecyclerView.Adapter<SkillViewHolder>(), SkillViewHolder.ClickListener {
 
+    private val DEFAULT_AUTHOR = "<author_name>"
+    private val DEFAULT_EXAMPLE = "<The question that should be shown in public skill displays>"
     private val imageLink = "https://raw.githubusercontent.com/fossasia/susi_skill_data/master/models/general/"
     private val clickListener: SkillViewHolder.ClickListener = this
 
@@ -37,13 +39,13 @@ class SkillsListAdapter(
             holder.skillName.text = skillData.skillName
         }
 
-        if (skillData.author.isEmpty() || skillData.author.equals(context.getString(R.string.default_author_name))) {
+        if (skillData.author.isEmpty() || skillData.author.equals(DEFAULT_AUTHOR)) {
             holder.skillAuthorName.text = context.getString(R.string.no_skill_author)
         } else {
             holder.skillAuthorName.text = skillData.author
         }
 
-        if (skillData.examples.isEmpty() || skillData.examples.contains(context.getString(R.string.default_example)))
+        if (skillData.examples.isEmpty() || skillData.examples.contains(DEFAULT_EXAMPLE))
             holder.skillExample.text = ""
         else
             holder.skillExample.text = StringBuilder("\"").append(skillData.examples[0]).append("\"")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -438,10 +438,6 @@
     <string name="report_send_success">Skill reported successfully</string>
     <string name="reported_already">Skill already reported</string>
 
-    <!--Default placeholder values of skills description-->
-    <string name="default_author_name" translatable="false">&lt;author_name&gt;</string>
-    <string name="default_example" translatable="false">&lt;The question that should be shown in public skill displays&gt;</string>
-
     <!--Privacy -->
     <string name="privacy_welcome">Welcome to SUSI.AI</string>
     <string name="privacy_welcome_details">Thanks for using our products and services (“Services”). The Services are provided by SUSI Inc. (“SUSI”), located at 93 Mau Than, Can Tho City, Viet Nam. By using our Services, you are agreeing to these terms. Please read them carefully.</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -438,6 +438,10 @@
     <string name="report_send_success">Skill reported successfully</string>
     <string name="reported_already">Skill already reported</string>
 
+    <!--Default placeholder values of skills description-->
+    <string name="default_author_name" translatable="false">&lt;author_name&gt;</string>
+    <string name="default_example" translatable="false">&lt;The question that should be shown in public skill displays&gt;</string>
+
     <!--Privacy -->
     <string name="privacy_welcome">Welcome to SUSI.AI</string>
     <string name="privacy_welcome_details">Thanks for using our products and services (“Services”). The Services are provided by SUSI Inc. (“SUSI”), located at 93 Mau Than, Can Tho City, Viet Nam. By using our Services, you are agreeing to these terms. Please read them carefully.</string>


### PR DESCRIPTION
Fixes #2071 

Changes: Now placeholder values of example and author name of skill data is not showing
