### PR TITLE
fix: fixes the typo in Manifest file

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -69,7 +69,7 @@
 
         <!--
         For Developers:
-        Replay the fabric_api_key to your actual API KEY
+        Replace the fabric_api_key to your actual API KEY
         <meta-data
             android:name="io.fabric.ApiKey"
             android:value="fabric_api_key" />


### PR DESCRIPTION
Fixes #2088 

Changes: 
Changed the typo from "Replay" to "Replace" in Manifest file
