### PR TITLE
chore: intent to skills activity disabled on language change

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -126,10 +126,6 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
             if (!settingsPresenter.getAnonymity()) {
                 settingsPresenter.sendSetting(Constant.LANGUAGE, newValue.toString(), 1)
             }
-            val intent = Intent(context, SkillsActivity::class.java)
-            startActivity(intent)
-            val context = this.context
-            if (context is Activity) context.finish()
             true
         }
         rate.setOnPreferenceClickListener {

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -1,7 +1,6 @@
 package org.fossasia.susi.ai.skills.settings
 
 import android.Manifest
-import android.app.Activity
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri


### PR DESCRIPTION
**Changes:**
On changing the language in settings, it directly starts an intent to the skills activity. But this should not be the case as while changing settings, a user would never want to be migrated to somewhere else, especially while changing a language.

**P.S**.-> These changes are just based on the reviews from my friends. These are not much relevant.