### PR TITLE
fix: settings crash after changing language

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -40,7 +40,6 @@
     <string name="activity_executed_key" translatable="false">activity_executed</string>
     <string name="anonymous_logged_in_key" translatable="false">anonymous_logged_in</string>
     <string name="susi_server_selected_key" translatable="false">is_susi_server_selected</string>
-    <string name="hotword_detection_key" translatable="false">hotword_detection</string>
     <string name="notify_user_key" translatable="false">notify_user</string>
 
     <string name="websearchnull">Keine Ergebnisse gefunden</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -31,7 +31,6 @@
     <string name="activity_executed_key" translatable="false">activity_executed</string>
     <string name="anonymous_logged_in_key" translatable="false">anonymous_logged_in</string>
     <string name="susi_server_selected_key" translatable="false">is_susi_server_selected</string>
-    <string name="hotword_detection_key" translatable="false">hotword_detection</string>
     <string name="notify_user_key" translatable="false">notify_user</string>
     <string name="email_not_registered">El correo electrónico que ha introducido no se ha registrado con nosotros. Inténtalo de nuevo.</string>
     <string name="email_not_registered_title">registro de email</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -61,7 +61,6 @@
     <string name="setting_hotword_detection">हॉटवर्ड डिटेक्शन (बीटा)</string>
 
     <string name="setting_mic_key" translatable="false">mic_input</string>
-    <string name="setting_hotword_key" translatable="false">हॉटवर्ड डिटेक्शन</string>
     <string name="settings_enterPreference_key" translatable="false">enter_send</string>
     <string name="settings_speechPreference_key" translatable="false">speech_output</string>
     <string name="settings_speechAlways_key" translatable="false">भाषण आउटपुट हमेशा</string>
@@ -84,7 +83,6 @@
     <string name="activity_executed_key" translatable="false">activity_executed</string>
     <string name="anonymous_logged_in_key" translatable="false">anonymous_logged_in</string>
     <string name="susi_server_selected_key" translatable="false">is_susi_server_selected</string>
-    <string name="hotword_detection_key" translatable="false">hotword_detection</string>
     <string name="notify_user_key" translatable="false">notify_user</string>
 
     <!--Material Dialog-->

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -70,7 +70,6 @@
     <string name="activity_executed_key" translatable="false">activity_executed</string>
     <string name="anonymous_logged_in_key" translatable="false">anonymous_logged_in</string>
     <string name="susi_server_selected_key" translatable="false">is_susi_server_selected</string>
-    <string name="hotword_detection_key" translatable="false">hotword_detection</string>
     <string name="notify_user_key" translatable="false">notify_user</string>
 
     <!--Error Messages-->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -66,7 +66,6 @@
     <string name="activity_executed_key" translatable="false">activity_executed</string>
     <string name="anonymous_logged_in_key" translatable="false">anonymous_logged_in</string>
     <string name="susi_server_selected_key" translatable="false">is_susi_server_selected</string>
-    <string name="hotword_detection_key" translatable="false">hotword_detection</string>
     <string name="notify_user_key" translatable="false">notify_user</string>
 
     <!--Error Messages-->


### PR DESCRIPTION
Fixes #2122 #1879 

Reasons for Crash: In ChatSettingsFragment, findPreference(key) method returns null to hotword detection which should not be the case. Null was returned due to invalid key passed when language is changed to Hindi.

Changes: I've removed the unwanted Hindi and other languages key to avoid the crash.
