### PR TITLE
removed about us from setting

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -47,7 +47,6 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
     private lateinit var hotwordSettings: Preference
     lateinit var share: Preference
     private lateinit var loginLogout: Preference
-    private lateinit var aboutUs: Preference
     private lateinit var resetPassword: Preference
     private lateinit var enterSend: Preference
     private lateinit var speechAlways: SwitchPreference
@@ -83,7 +82,6 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
         hotwordSettings = preferenceManager.findPreference(Constant.HOTWORD_DETECTION)
         share = preferenceManager.findPreference(Constant.SHARE)
         loginLogout = preferenceManager.findPreference(Constant.LOGIN_LOGOUT)
-        aboutUs = preferenceManager.findPreference(getString(R.string.settings_about_us_key))
         resetPassword = preferenceManager.findPreference(Constant.RESET_PASSWORD)
         enterSend = preferenceManager.findPreference(getString(R.string.settings_enterPreference_key))
         speechOutput = preferenceManager.findPreference(getString(R.string.settings_speechPreference_key)) as SwitchPreference
@@ -131,15 +129,6 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
         }
         rate.setOnPreferenceClickListener {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse("http://play.google.com/store/apps/details?id=" + packageName)))
-            true
-        }
-
-        aboutUs.setOnPreferenceClickListener {
-            val aboutFragment = AboutUsFragment()
-            fragmentManager?.beginTransaction()
-                    ?.replace(R.id.fragment_container, aboutFragment, TAG_ABOUT_FRAGMENT)
-                    ?.addToBackStack(TAG_ABOUT_FRAGMENT)
-                    ?.commit()
             true
         }
         share.setOnPreferenceClickListener {

--- a/app/src/main/res/xml/pref_settings.xml
+++ b/app/src/main/res/xml/pref_settings.xml
@@ -108,9 +108,6 @@
             android:key="login_logout"
             android:title="Login" />
 
-        <PreferenceScreen
-            android:key="@string/settings_about_us_key"
-            android:title="@string/settings_about_us" />
     </PreferenceCategory>
 
 


### PR DESCRIPTION
Changes: Removed aboutus from settings as it is evidently visible in menu bar. The room is for other essential things
Screenshots for the change: 
![Screenshot_20190407-180141_SUSIAI](https://user-images.githubusercontent.com/37215508/55685287-e3d3dd00-5971-11e9-80a7-5075862f7d84.jpg)

