### PR TITLE
fix: Moved help, privacy, about option from menu to settings

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
@@ -19,9 +19,7 @@ import org.fossasia.susi.ai.helper.Utils.hideSoftKeyboard
 import org.fossasia.susi.ai.login.LoginActivity
 import org.fossasia.susi.ai.rest.responses.susi.SkillData
 import org.fossasia.susi.ai.signup.SignUpActivity
-import org.fossasia.susi.ai.skills.aboutus.AboutUsFragment
 import org.fossasia.susi.ai.skills.groupwiseskills.GroupWiseSkillsFragment
-import org.fossasia.susi.ai.skills.help.HelpFragment
 import org.fossasia.susi.ai.skills.privacy.PrivacyFragment
 import org.fossasia.susi.ai.skills.settings.ChatSettingsFragment
 import org.fossasia.susi.ai.skills.settings.SettingsPresenter
@@ -42,8 +40,6 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
 
     private val TAG_SETTINGS_FRAGMENT = "SettingsFragment"
     private val TAG_SKILLS_FRAGMENT = "SkillsFragment"
-    private val TAG_ABOUT_FRAGMENT = "AboutUsFragment"
-    private val TAG_HELP_FRAGMENT = "HelpFragment"
     private val TAG_PRIVACY_FRAGMENT = "PrivacyFragment"
     private val TAG_GROUP_WISE_SKILLS_FRAGMENT = "GroupWiseSkillsFragment"
 
@@ -144,23 +140,6 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
                         .commit()
             }
 
-            R.id.menu_about -> {
-                handleOnLoadingFragment()
-                val aboutFragment = AboutUsFragment()
-                supportFragmentManager.beginTransaction()
-                        .replace(R.id.fragment_container, aboutFragment, TAG_ABOUT_FRAGMENT)
-                        .addToBackStack(TAG_ABOUT_FRAGMENT)
-                        .commit()
-            }
-            R.id.menu_help -> {
-                handleOnLoadingFragment()
-                val helpFragment = HelpFragment()
-                supportFragmentManager.beginTransaction()
-                        .replace(R.id.fragment_container, helpFragment, TAG_HELP_FRAGMENT)
-                        .addToBackStack(TAG_HELP_FRAGMENT)
-                        .commit()
-            }
-
             R.id.menu_login -> {
                 handleOnLoadingFragment()
                 if (!settingsPresenter.getAnonymity()) {
@@ -188,15 +167,6 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
                 handleOnLoadingFragment()
                 val intent = Intent(this, SignUpActivity::class.java)
                 startActivity(intent)
-            }
-
-            R.id.menu_privacy -> {
-                handleOnLoadingFragment()
-                val aboutFragment = PrivacyFragment()
-                supportFragmentManager.beginTransaction()
-                        .replace(R.id.fragment_container, aboutFragment, TAG_PRIVACY_FRAGMENT)
-                        .addToBackStack(TAG_PRIVACY_FRAGMENT)
-                        .commit()
             }
 
             R.id.action_search -> {

--- a/app/src/main/java/org/fossasia/susi/ai/skills/privacy/PrivacyFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/privacy/PrivacyFragment.kt
@@ -19,7 +19,7 @@ class PrivacyFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         val thisActivity = activity
-        thisActivity?.title = getString(R.string.menu_item_privacy)
+        thisActivity?.title = getString(R.string.settings_privacy)
         val rootView = inflater.inflate(R.layout.fragment_privacy, container, false)
         setHasOptionsMenu(true)
         return rootView

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -55,8 +55,8 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
     lateinit var share: Preference
     private lateinit var loginLogout: Preference
     private lateinit var aboutUs: Preference
-    private lateinit var help : Preference
-    private lateinit var privacy:Preference
+    private lateinit var help: Preference
+    private lateinit var privacy: Preference
     private lateinit var resetPassword: Preference
     private lateinit var enterSend: Preference
     private lateinit var speechAlways: SwitchPreference

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -32,6 +32,8 @@ import org.fossasia.susi.ai.skills.settings.contract.ISettingsView
 import timber.log.Timber
 import java.util.Locale
 import android.content.ActivityNotFoundException
+import org.fossasia.susi.ai.skills.help.HelpFragment
+import org.fossasia.susi.ai.skills.privacy.PrivacyFragment
 
 /**
  * The Fragment for Settings Activity
@@ -42,6 +44,8 @@ import android.content.ActivityNotFoundException
 class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
 
     private val TAG_ABOUT_FRAGMENT = "AboutUsFragment"
+    private val TAG_HELP_FRAGMENT = "HelpFragment"
+    private val TAG_PRIVACY_FRAGMENT = "PrivacyFragment"
     private lateinit var settingsPresenter: ISettingsPresenter
 
     private lateinit var rate: Preference
@@ -51,6 +55,8 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
     lateinit var share: Preference
     private lateinit var loginLogout: Preference
     private lateinit var aboutUs: Preference
+    private lateinit var help : Preference
+    private lateinit var privacy:Preference
     private lateinit var resetPassword: Preference
     private lateinit var enterSend: Preference
     private lateinit var speechAlways: SwitchPreference
@@ -88,6 +94,8 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
         share = preferenceManager.findPreference(Constant.SHARE)
         loginLogout = preferenceManager.findPreference(Constant.LOGIN_LOGOUT)
         aboutUs = preferenceManager.findPreference(getString(R.string.settings_about_us_key))
+        help = preferenceManager.findPreference(getString(R.string.settings_help_key))
+        privacy = preferenceManager.findPreference(getString(R.string.settings_privacy_key))
         resetPassword = preferenceManager.findPreference(Constant.RESET_PASSWORD)
         enterSend = preferenceManager.findPreference(getString(R.string.settings_enterPreference_key))
         speechOutput = preferenceManager.findPreference(getString(R.string.settings_speechPreference_key)) as SwitchPreference
@@ -144,6 +152,24 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
             fragmentManager?.beginTransaction()
                     ?.replace(R.id.fragment_container, aboutFragment, TAG_ABOUT_FRAGMENT)
                     ?.addToBackStack(TAG_ABOUT_FRAGMENT)
+                    ?.commit()
+            true
+        }
+
+        help.setOnPreferenceClickListener {
+            val helpFragment = HelpFragment()
+            fragmentManager?.beginTransaction()
+                    ?.replace(R.id.fragment_container, helpFragment, TAG_HELP_FRAGMENT)
+                    ?.addToBackStack(TAG_HELP_FRAGMENT)
+                    ?.commit()
+            true
+        }
+
+        privacy.setOnPreferenceClickListener {
+            val privacyFragment = PrivacyFragment()
+            fragmentManager?.beginTransaction()
+                    ?.replace(R.id.fragment_container, privacyFragment, TAG_PRIVACY_FRAGMENT)
+                    ?.addToBackStack(TAG_PRIVACY_FRAGMENT)
                     ?.commit()
             true
         }

--- a/app/src/main/res/menu/skills_activity_menu.xml
+++ b/app/src/main/res/menu/skills_activity_menu.xml
@@ -8,25 +8,15 @@
             android:icon="@drawable/ic_settings_24dp"
             android:title="@string/menu_item_settings" />
         <item
-            android:id="@+id/menu_about"
-            android:icon="@drawable/ic_about"
-            android:title="@string/menu_item_about" />
-        <item
             android:id="@+id/menu_login"
             android:title="@string/action_login" />
         <item
             android:id="@+id/menu_signup"
             android:title="@string/sign_up" />
         <item
-            android:id="@+id/menu_privacy"
-            android:title="@string/menu_item_privacy" />
-        <item
             android:id="@+id/action_search"
             android:icon="@drawable/ic_open_search"
             android:title="@string/search"
             app:showAsAction="ifRoom" />
-        <item
-            android:id="@+id/menu_help"
-            android:title="@string/menu_item_help" />
     </group>
 </menu>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -338,4 +338,8 @@
     <string name="post_feedback_for_anonymous_user">Bitte melden Sie sich an, um ein Feedback zu geben</string>
     <string name="set_up">KONFIGURATION</string>
     <string name="susi_contributors">Mitwirkende</string>
+    <string name="settings_help">Hilfe</string>
+    <string name="settings_help_key">Hilfe</string>
+    <string name="settings_privacy">Privatsphäre</string>
+    <string name="settings_privacy_key">Privatsphäre</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -330,4 +330,8 @@ Enlace de confirmación para activar su cuenta e iniciar sesión en susi.</strin
     <string name="feedback_section">realimentación</string>
     <string name="rate_hate">lo odié</string>
     <string name="skill_unrated_for_anonymous_user">Habilidad no clasificada aún. Por favor, inicie sesión para calificar la habilidad.</string>
+    <string name="settings_help">ayuda</string>
+    <string name="settings_help_key">ayuda</string>
+    <string name="settings_privacy">intimidad</string>
+    <string name="settings_privacy_key">intimidad</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -337,4 +337,8 @@
     <string name="example_feedback">Feedback di esempio</string>
     <string name="examples">Esempi</string>
     <string name="existing_user_login">Utente esistente?</string>
+    <string name="settings_help">Aiuto</string>
+    <string name="settings_help_key">Aiuto</string>
+    <string name="settings_privacy">vita privata</string>
+    <string name="settings_privacy_key">vita privata</string>
 </resources>

--- a/app/src/main/res/values-ml-rIN/strings.xml
+++ b/app/src/main/res/values-ml-rIN/strings.xml
@@ -322,4 +322,8 @@
     <string name="settings_visit_website">വെബ്സൈറ്റ് സന്ദർശിക്കുക</string>
     <string name="error_skipping_signUp_process_text">ഇത് സൈൻ അപ്പ് പ്രോസസ്സ് റദ്ദാക്കുകയും ചാറ്റ് പേജിലേക്ക് നിങ്ങളെ റീഡയറക്ട് ചെയ്യുകയും ചെയ്യും.</string>
     <string name="dialog_skip_sign_up">സൈൻ അപ് ചെയ്യണോ?</string>
+    <string name="settings_help">உதவி</string>
+    <string name="settings_help_key">உதவி</string>
+    <string name="settings_privacy">தனியுரிமை</string>
+    <string name="settings_privacy_key">தனியுரிமை</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -335,4 +335,8 @@
     <string name="no_skill_name">Nome não disponível</string>
     <string name="new_password">Nova senha</string>
     <string name="privacy_business_details">Se você estiver usando nossos serviços em nome de uma empresa, essa empresa aceita esses termos. Ele isentará e indenizará a SUSI e suas afiliadas, executivos, agentes e funcionários de qualquer reclamação, ação ou ação decorrente ou relacionada ao uso dos Serviços ou violação destes termos, incluindo qualquer responsabilidade ou despesa decorrente de reclamações, perdas. , danos, ações, julgamentos, custos de litígios e honorários advocatícios.</string>
+    <string name="settings_help">Socorro</string>
+    <string name="settings_help_key">Socorro</string>
+    <string name="settings_privacy">privacidade</string>
+    <string name="settings_privacy_key">privacidade</string>
 </resources>

--- a/app/src/main/res/values-ta-rIN/strings.xml
+++ b/app/src/main/res/values-ta-rIN/strings.xml
@@ -320,4 +320,8 @@
     <string name="settings_visit_website">வலைத்தளத்தைப் பார்வையிடவும்</string>
     <string name="error_skipping_signUp_process_text">இது உள்நுழைவு செயல்முறையை ரத்துசெய்து, அரட்டை பக்கத்திற்கு உங்களை திருப்பி விடுகிறது.</string>
     <string name="dialog_skip_sign_up">உள்நுழையவும்?</string>
+    <string name="settings_help">സഹായിക്കൂ</string>
+    <string name="settings_help_key">സഹായിക്കൂ</string>
+    <string name="settings_privacy">സ്വകാര്യത</string>
+    <string name="settings_privacy_key">സ്വകാര്യത</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -515,4 +515,8 @@
         \nYou agree that the laws of Can Tho, Vietnam will apply to any disputes arising out of or relating to these terms or the Services. All claims arising out of or relating to these terms or the services will be litigated exclusively in the courts of Can Tho City, Vietnam, and you and SUSI consent to personal jurisdiction in those courts.
         \nFor information about how to contact SUSI, please visit our contact page.</string>
     <string name="title_activity_chat_search_main">ChatSearchMainActivity</string>
+    <string name="settings_help">Help</string>
+    <string name="settings_help_key">help</string>
+    <string name="settings_privacy">Privacy</string>
+    <string name="settings_privacy_key">privacy</string>
 </resources>

--- a/app/src/main/res/xml/pref_settings.xml
+++ b/app/src/main/res/xml/pref_settings.xml
@@ -115,6 +115,14 @@
         <PreferenceScreen
             android:key="@string/settings_visit_website_key"
             android:title="@string/settings_visit_website" />
+
+        <PreferenceScreen
+            android:key="@string/settings_help_key"
+            android:title="@string/settings_help" />
+
+        <PreferenceScreen
+            android:key="@string/settings_privacy_key"
+            android:title="@string/settings_privacy" />
     </PreferenceCategory>
 
 


### PR DESCRIPTION
Fixes #2152 

Changes: Transferred Privacy, Help, ABout option from the menu to the settings page.

Screenshots for the change: 
<img width="336" alt="Screenshot 2019-05-10 at 11 11 53 AM" src="https://user-images.githubusercontent.com/43731599/57505188-fd6f9800-7314-11e9-9689-f0959ae61476.png">

<img width="328" alt="Screenshot 2019-05-10 at 11 12 17 AM" src="https://user-images.githubusercontent.com/43731599/57505150-db761580-7314-11e9-9919-43a3a1e593ca.png">
