### PR TITLE
fix: Hyperlinked words in textview instead of whole textview

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/aboutus/AboutUsFragment.kt
@@ -1,20 +1,17 @@
 package org.fossasia.susi.ai.skills.aboutus
 
-import android.net.Uri
 import android.os.Build
 import android.os.Bundle
 import android.support.annotation.NonNull
-import android.support.customtabs.CustomTabsIntent
 import android.support.v4.app.Fragment
 import android.text.Html
 import android.text.Spanned
+import android.text.method.LinkMovementMethod
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Toast
 import kotlinx.android.synthetic.main.fragment_about_us.*
 import org.fossasia.susi.ai.R
-import org.fossasia.susi.ai.helper.Constant
 import org.fossasia.susi.ai.skills.SkillsActivity
 
 class AboutUsFragment : Fragment() {
@@ -34,34 +31,8 @@ class AboutUsFragment : Fragment() {
 
     @NonNull
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        about_susi.setOnClickListener {
-            val uri = Uri.parse(getString(R.string.url_about_susi))
-            launchCustomtTab(uri)
-        }
+        super.onViewCreated(view, savedInstanceState)
 
-        contributors_desc.setOnClickListener {
-            val uri = Uri.parse(getString(R.string.url_susi_contributors))
-            launchCustomtTab(uri)
-        }
-
-        susi_skill_cms_desc.setOnClickListener {
-            val uri = Uri.parse(getString(R.string.url_susi_skill_cms))
-            launchCustomtTab(uri)
-        }
-
-        susi_report_issues_desc.setOnClickListener {
-            val uri = Uri.parse(getString(R.string.url_susi_report_issue))
-            launchCustomtTab(uri)
-        }
-        susi_license_info_desc.setOnClickListener {
-            val uri = Uri.parse(getString(R.string.url_susi_license))
-            launchCustomtTab(uri)
-        }
-
-        know_more_about_susi.setOnClickListener {
-            val uri = Uri.parse(Constant.susi_know_more_url)
-            launchCustomtTab(uri)
-        }
         about_susi.text = htmlConverter(R.string.susi_about)
         contributors_desc.text = htmlConverter(R.string.susi_contributors_desc)
         susi_skill_cms_desc.text = htmlConverter(R.string.susi_skill_cms_desc)
@@ -69,15 +40,12 @@ class AboutUsFragment : Fragment() {
         susi_report_issues_desc.text = htmlConverter(R.string.susi_report_issues_desc)
         know_more_about_susi.text = htmlConverter(R.string.susi_know_more)
 
-        super.onViewCreated(view, savedInstanceState)
-    }
-
-    private fun launchCustomtTab(uri: Uri) {
-        try {
-            CustomTabsIntent.Builder().build().launchUrl(context, uri) //launching through custom tabs
-        } catch (e: Exception) {
-            Toast.makeText(context, getString(R.string.link_unavailable), Toast.LENGTH_SHORT).show()
-        }
+        about_susi.setMovementMethod(LinkMovementMethod.getInstance())
+        contributors_desc.setMovementMethod(LinkMovementMethod.getInstance())
+        susi_skill_cms_desc.setMovementMethod(LinkMovementMethod.getInstance())
+        susi_license_info_desc.setMovementMethod(LinkMovementMethod.getInstance())
+        susi_report_issues_desc.setMovementMethod(LinkMovementMethod.getInstance())
+        know_more_about_susi.setMovementMethod(LinkMovementMethod.getInstance())
     }
 
     private fun htmlConverter(resourceId: Int): Spanned {

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -173,15 +173,15 @@
     <string name="reset_password_message">पासवर्ड रीसेट करना ..</string>
 
     <!--About Us String-->
-    <string name="susi_about"><a href="https://chat.susi.ai/overview">सुसी एआई</a> एक बुद्धिमान ओपन सोर्स व्यक्तिगत सहायक है यह म्यूजिक प्लेबैक, टू-डू सूचियों बनाने, अलार्म सेट करने, पॉडकास्ट स्ट्रीमिंग, ऑडीओबूक चलाने और मौसम, ट्रैफ़िक और अन्य वास्तविक समय की जानकारी प्रदान करने के लिए एपीआई का उपयोग करके चैट और आवाज बातचीत करने में सक्षम है। बाहरी एपीआई का उपयोग कर कंसोल सेवाओं के रूप में अतिरिक्त कार्यशीलताओं को जोड़ा जा सकता है सुशी एआई सवालों के जवाब देने में सक्षम है और संदर्भ के आधार पर वांछित परिणामों को पूरा करने के लिए अतिरिक्त जानकारी मांगेगा। सहायक का मुख्य सुशी एआई सर्वर है जो सूसी एआई के "इंटेलिजेंस" और "व्यक्तित्व" रखता है।</string>
+    <string name="susi_about"><![CDATA[<a href="https://chat.susi.ai/overview">सुसी एआई</a>]]> एक बुद्धिमान ओपन सोर्स व्यक्तिगत सहायक है यह म्यूजिक प्लेबैक, टू-डू सूचियों बनाने, अलार्म सेट करने, पॉडकास्ट स्ट्रीमिंग, ऑडीओबूक चलाने और मौसम, ट्रैफ़िक और अन्य वास्तविक समय की जानकारी प्रदान करने के लिए एपीआई का उपयोग करके चैट और आवाज बातचीत करने में सक्षम है। बाहरी एपीआई का उपयोग कर कंसोल सेवाओं के रूप में अतिरिक्त कार्यशीलताओं को जोड़ा जा सकता है सुशी एआई सवालों के जवाब देने में सक्षम है और संदर्भ के आधार पर वांछित परिणामों को पूरा करने के लिए अतिरिक्त जानकारी मांगेगा। सहायक का मुख्य सुशी एआई सर्वर है जो सूसी एआई के "इंटेलिजेंस" और "व्यक्तित्व" रखता है।</string>
     <string name="susi_contributors">योगदानकर्ता</string>
-    <string name="susi_contributors_desc">द्वारा विकसित <a href="https://github.com/fossasia/susi_android/graphs/contributors">द्वारा विकसित</a>.</string>
+    <string name="susi_contributors_desc">द्वारा विकसित <![CDATA[<a href="https://github.com/fossasia/susi_android/graphs/contributors">द्वारा विकसित</a>]]>.</string>
     <string name="susi_skill_cms">एसयूएसआई कौशल सेमी</string>
-    <string name="susi_skill_cms_desc">SUSI में कई कौशल हैं आप कौशल के संग्रह को देख सकते हैं<a href="http://www.skills.susi.ai">skills.susi.ai</a>। एसयूएसआई कौशल विकास आसान और मजेदार है आप मौजूदा कौशल को संपादित कर सकते हैं या अपना स्वयं का बना सकते हैं।</string>
+    <string name="susi_skill_cms_desc">SUSI में कई कौशल हैं आप कौशल के संग्रह को देख सकते हैं<![CDATA[a href="http://www.skills.susi.ai">skills.susi.ai</a>]]>। एसयूएसआई कौशल विकास आसान और मजेदार है आप मौजूदा कौशल को संपादित कर सकते हैं या अपना स्वयं का बना सकते हैं।</string>
     <string name="susi_report_issues">रिपोर्ट के मुद्दे</string>
-    <string name="susi_report_issues_desc">कृपया सभी मुद्दों की रिपोर्ट करें <a href="https://github.com/fossasia/susi_android/issues">जिथुब रिपोजिटरी इश्यू ट्रैकर</a>.</string>
+    <string name="susi_report_issues_desc">कृपया सभी मुद्दों की रिपोर्ट करें <![CDATA[<a href="https://github.com/fossasia/susi_android/issues">जिथुब रिपोजिटरी इश्यू ट्रैकर</a>]]>.</string>
     <string name="susi_license_information">लाइसेंस</string>
-    <string name="susi_license_information_desc">यह परियोजना वर्तमान में अपाचे लाइसेंस संस्करण 2.0 के तहत लाइसेंस प्राप्त है। एक प्रतिलिप <a href="https://github.com/fossasia/susi_android/blob/master/LICENSE">LICENSE.md</a> </string>
+    <string name="susi_license_information_desc">यह परियोजना वर्तमान में अपाचे लाइसेंस संस्करण 2.0 के तहत लाइसेंस प्राप्त है। एक प्रतिलिप <![CDATA[<a href="https://github.com/fossasia/susi_android/blob/master/LICENSE">LICENSE.md</a>]]> </string>
 
     <!-- Intro Strings -->
     <string name="next">आगामी</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -300,23 +300,22 @@
 
     <!--About Us String-->
     <string name="url_about_susi" translatable="false">https://chat.susi.ai/overview</string>
-    <string name="susi_about">
-        <a href="https://chat.susi.ai/overview"><![CDATA[<u><font color='#4184f3'>SUSI.AI</u></font>]]></a> is an intelligent libre software personal assistant. It is capable of chat and voice interaction by using APIs to perform actions such as music playback, making to-do lists, setting alarms, streaming podcasts, playing audiobooks, and providing weather, traffic, and other real time information. Additional functionalities can be added as console services using external APIs. SUSI.AI is able to answer questions and depending on the context will ask for additional information in order to perform the desired outcome. The core of the assistant is the SUSI.AI server that holds the "intelligence" and "personality" of SUSI.AI.</string>
+    <string name="susi_about"><![CDATA[<a href="https://chat.susi.ai/overview"><u><font color=\'#4184f3\'>SUSI.AI</u></font></a>]]> is an intelligent libre software personal assistant. It is capable of chat and voice interaction by using APIs to perform actions such as music playback, making to-do lists, setting alarms, streaming podcasts, playing audiobooks, and providing weather, traffic, and other real time information. Additional functionalities can be added as console services using external APIs. SUSI.AI is able to answer questions and depending on the context will ask for additional information in order to perform the desired outcome. The core of the assistant is the SUSI.AI server that holds the "intelligence" and "personality" of SUSI.AI.</string>
     <string name="susi_contributors">Contributors</string>
     <string name="url_susi_contributors" translatable="false">https://github.com/fossasia/susi_android/graphs/contributors</string>
-    <string name="susi_contributors_desc">Developed by <a href="https://github.com/fossasia/susi_android/graphs/contributors"><![CDATA[<u><font color='#4184f3'>Contributors</u></font>]]></a>.</string>
+    <string name="susi_contributors_desc"><![CDATA[Developed by <a href="https://github.com/fossasia/susi_android/graphs/contributors"><u><font color='#4184f3'>Contributors</u></font></a>]]>.</string>
     <string name="susi_license_information">License</string>
     <string name="url_susi_license" translatable="false">https://github.com/fossasia/susi_android/blob/master/LICENSE</string>
-    <string name="susi_license_information_desc">This project is currently licensed under the Apache License Version 2.0. As per the <a href="https://github.com/fossasia/susi_android/blob/master/LICENSE"><![CDATA[<u><font color='#4184f3'>LICENSE.md</u></font>]]></a>
+    <string name="susi_license_information_desc">This project is currently licensed under the Apache License Version 2.0. As per the <![CDATA[<a href="https://github.com/fossasia/susi_android/blob/master/LICENSE"><u><font color='#4184f3'>LICENSE.md</u></font></a>]]>
     </string>
     <string name="susi_report_issues">Report Issues</string>
     <string name="url_susi_report_issue" translatable="false">https://github.com/fossasia/susi_android/issues</string>
-    <string name="susi_report_issues_desc">Please report all the issues in <a href="https://github.com/fossasia/susi_android/issues"><![CDATA[<u><font color='#4184f3'>Github Repository Issue Tracker</u></font>]]></a>.</string>
+    <string name="susi_report_issues_desc">Please report all the issues in <![CDATA[<a href="https://github.com/fossasia/susi_android/issues"><u><font color='#4184f3'>Github Repository Issue Tracker</u></font></a>]]>.</string>
 
     <string name="susi_skill_cms">SUSI Skill CMS</string>
     <string name="url_susi_skill_cms" translatable="false">https://skills.susi.ai</string>
-    <string name="susi_skill_cms_desc">SUSI is having many skills. You can look at the collection of skills at <a href="http://www.skills.susi.ai"><![CDATA[<u><font color='#4184f3'>skills.susi.ai</u></font>]]></a>. SUSI Skill development is easy and fun. You can edit existing skills or even create your own.</string>
-    <string name="susi_know_more" translatable="false"><![CDATA[<u><font color=\'#4184f3\'>Click here to Know More</u></font>]]></string>
+    <string name="susi_skill_cms_desc">SUSI is having many skills. You can look at the collection of skills at <![CDATA[<a href="http://www.skills.susi.ai"><u><font color='#4184f3'>skills.susi.ai</u></font></a>]]>. SUSI Skill development is easy and fun. You can edit existing skills or even create your own.</string>
+    <string name="susi_know_more" translatable="false"><![CDATA[<a href="https://dev.susi.ai/"><u><font color=\'#4184f3\'>Click here to Know More</font></u></a>]]></string>
 
     <!-- Intro Strings -->
     <string name="author_name">Author name</string>


### PR DESCRIPTION
Fixes #1955 

Changes: 
* Corrected the present code of hyperlinking words in text view
* Updated the string format

Screenshots for the change: 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/43731599/57536072-0dad6480-7361-11e9-999f-f7cfff320ee9.gif)
