### PR TITLE
feat: Swap between login and signup page

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
@@ -7,6 +7,7 @@ import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import android.view.MotionEvent
 import android.view.View
 import android.view.inputmethod.EditorInfo
 import android.widget.ArrayAdapter
@@ -35,6 +36,8 @@ class LoginActivity : AppCompatActivity(), ILoginView {
     lateinit var builder: AlertDialog.Builder
     private lateinit var loginPresenter: ILoginPresenter
     private lateinit var progressDialog: ProgressDialog
+    var downX = 0.0f
+    var upX = 0.0f
 
     @SuppressLint("InflateParams")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -72,6 +75,32 @@ class LoginActivity : AppCompatActivity(), ILoginView {
         val string = bundle?.getString("email")
         if (string != null)
             email.editText?.setText(string)
+        handleLoginGestures()
+    }
+
+    private fun handleLoginGestures() {
+        login_scroll_view.setOnTouchListener(object : View.OnTouchListener {
+            override fun onTouch(v: View, event: MotionEvent): Boolean {
+                when (event.action) {
+                    MotionEvent.ACTION_DOWN -> {
+                        downX = event.getX()
+                    }
+                    MotionEvent.ACTION_UP -> {
+                        upX = event?.getX()
+
+                        var deltaX = downX - upX
+
+                        if (Math.abs(deltaX) > 200) { //Value set to 200 to avoid mild gestures
+                            val intent = Intent(this@LoginActivity, SignUpActivity::class.java)
+                            intent.putExtra("email", email.editText?.text.toString())
+                            startActivity(intent)
+                        }
+                    }
+                }
+                return false
+            }
+        }
+        )
     }
 
     override fun onLoginSuccess(message: String?) {

--- a/app/src/main/java/org/fossasia/susi/ai/signup/SignUpActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/signup/SignUpActivity.kt
@@ -9,9 +9,13 @@ import android.graphics.Color
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
 import android.view.MenuItem
+import android.view.MotionEvent
 import android.view.View
 import android.widget.Toast
 import kotlinx.android.synthetic.main.activity_sign_up.*
+import kotlinx.android.synthetic.main.activity_sign_up.email
+import kotlinx.android.synthetic.main.activity_sign_up.password
+import kotlinx.android.synthetic.main.activity_sign_up.signUp
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.chat.ChatActivity
 import org.fossasia.susi.ai.login.LoginActivity
@@ -37,6 +41,8 @@ class SignUpActivity : AppCompatActivity(), ISignUpView {
     private lateinit var forgotPasswordProgressDialog: Dialog
     private lateinit var builder: AlertDialog.Builder
     private var checkDialog: Boolean = false
+    var downX = 0.0f
+    var upX = 0.0f
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -78,6 +84,33 @@ class SignUpActivity : AppCompatActivity(), ISignUpView {
 
         signUpPresenter = SignUpPresenter(this)
         signUpPresenter.onAttach(this)
+
+        handleSignUpGestures()
+    }
+
+    private fun handleSignUpGestures() {
+        signup_scroll_view.setOnTouchListener(object : View.OnTouchListener {
+            override fun onTouch(v: View, event: MotionEvent): Boolean {
+                when (event.action) {
+                    MotionEvent.ACTION_DOWN -> {
+                        downX = event.getX()
+                    }
+                    MotionEvent.ACTION_UP -> {
+                        upX = event?.getX()
+
+                        var deltaX = downX - upX
+
+                        if (Math.abs(deltaX) > 200) { //value set to 200 to avoid mild gestures
+                            val intent = Intent(this@SignUpActivity, LoginActivity::class.java)
+                            intent.putExtra("email", email.editText?.text.toString())
+                            startActivity(intent)
+                        }
+                    }
+                }
+                return false
+            }
+        }
+        )
     }
 
     private fun addListeners() {
@@ -100,8 +133,8 @@ class SignUpActivity : AppCompatActivity(), ISignUpView {
                     startActivity(intent)
                     finish()
                 })
-                setNegativeButton(android.R.string.no, DialogInterface.OnClickListener {
-                    dialog, id -> dialog.cancel()
+                setNegativeButton(android.R.string.no, DialogInterface.OnClickListener { dialog, id ->
+                    dialog.cancel()
                 })
                 show()
             }

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:id="@+id/login_scroll_view"
     android:background="@color/default_bg">
 
     <LinearLayout

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -4,6 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:id="@+id/signup_scroll_view"
     android:background="@color/default_bg"
     tools:context="org.fossasia.susi.ai.signup.SignUpActivity">
 


### PR DESCRIPTION
Fixes #2097 

Changes: 
Id gave to the scrollview of login and signup activity
Using this id, onTouch Listener has been implemented.
Now user can move from login to signup page and vice versa by swap gesture

Screenshots for the change: 
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/43731599/57586928-b226d680-751a-11e9-9b24-03d1b08c9467.gif)
