### PR TITLE
fix: Fixed malfunction of settings fragment

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
@@ -228,4 +228,9 @@ class LoginActivity : AppCompatActivity(), ILoginView {
             loginPresenter.requestPassword(email, url, isPersonalServerChecked)
         }
     }
+
+    override fun onBackPressed() {
+        super.onBackPressed()
+        startActivity(Intent(this, ChatActivity::class.java))
+    }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
@@ -231,6 +231,8 @@ class LoginActivity : AppCompatActivity(), ILoginView {
 
     override fun onBackPressed() {
         super.onBackPressed()
-        startActivity(Intent(this, ChatActivity::class.java))
+        val intent = Intent(this, ChatActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+        startActivity(intent)
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
@@ -232,6 +232,5 @@ class LoginActivity : AppCompatActivity(), ILoginView {
     override fun onBackPressed() {
         super.onBackPressed()
         loginPresenter.skipLogin()
-        super.onBackPressed()
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -201,7 +201,6 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
             } else {
                 settingsPresenter.loginLogout()
                 val intent = Intent(context, LoginActivity::class.java)
-                intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
                 startActivity(intent)
             }
             true
@@ -220,7 +219,6 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
         displayEmail.setOnPreferenceClickListener {
             settingsPresenter.loginLogout()
             val intent = Intent(context, LoginActivity::class.java)
-            intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
             startActivity(intent)
             true
         }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -203,13 +203,9 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
                 alert.setTitle(getString(R.string.logout))
                 alert.show()
             } else {
-                <<<<<<< HEAD
-                settingsPresenter.loginLogout()
+                loginLogoutModulePresenter.logout()
                 val intent = Intent(context, LoginActivity::class.java)
                 startActivity(intent)
-                ====== =
-                loginLogoutModulePresenter.logout()
-                >>>>>>> a9e6bb6489b37229750071b8e2b272154ddf0899
             }
             true
         }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/settings/ChatSettingsFragment.kt
@@ -189,7 +189,7 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
         }
 
         loginLogout.setOnPreferenceClickListener {
-            if (!settingsPresenter.getAnonymity()) {
+            if (!settingsPresenter.getAnonymity() && utilModel.isLoggedIn()) {
                 val builder = AlertDialog.Builder(requireContext())
                 builder.setMessage(R.string.logout_confirmation).setCancelable(false).setPositiveButton(R.string.action_log_out) { _, _ ->
                     settingsPresenter.loginLogout()
@@ -200,6 +200,9 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
                 alert.show()
             } else {
                 settingsPresenter.loginLogout()
+                val intent = Intent(context, LoginActivity::class.java)
+                intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+                startActivity(intent)
             }
             true
         }
@@ -216,6 +219,9 @@ class ChatSettingsFragment : PreferenceFragmentCompat(), ISettingsView {
 
         displayEmail.setOnPreferenceClickListener {
             settingsPresenter.loginLogout()
+            val intent = Intent(context, LoginActivity::class.java)
+            intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK
+            startActivity(intent)
             true
         }
 


### PR DESCRIPTION
Fixes #2055 

Changes: [Add here what changes were made in this issue and if possible provide links.]
Fixed it by checking whether the user is logged in or not. Initially, it used only anonymity as a parameter to check

Screenshots for the change: 
![settings](https://user-images.githubusercontent.com/43731599/57731459-4da17e00-76b8-11e9-8e21-32653bf10221.gif)
