### PR TITLE
chore: bump gradle from 3.3.2 to 3.4.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ buildscript {
         google()
     }
     dependencies {
-        classpath "com.android.tools.build:gradle:3.3.2"
+        classpath "com.android.tools.build:gradle:3.4.1"
         classpath "com.jfrog.bintray.gradle:gradle-bintray-plugin:1.2"
         classpath "com.github.dcendents:android-maven-gradle-plugin:2.1"
         classpath "io.realm:realm-gradle-plugin:5.8.0"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri May 17 15:10:56 IST 2019
+#Fri May 17 18:59:04 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.4.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jan 26 14:32:06 IST 2019
+#Fri May 17 15:10:56 IST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Fixes #2212

Changes: 
Upgarded the required files.
Fixed the gradle build.
Probably developers have to update to the latest version of the android studio, to prevent any errors from rising.

Screenshots for the change: 
<img width="1680" alt="Screenshot 2019-05-17 at 3 52 48 PM" src="https://user-images.githubusercontent.com/43731599/57922119-9f1a5a80-78bc-11e9-9fa2-5986403d436b.png">
