### PR TITLE
fix: Back press in login activity handled

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
@@ -228,4 +228,9 @@ class LoginActivity : AppCompatActivity(), ILoginView {
             loginPresenter.requestPassword(email, url, isPersonalServerChecked)
         }
     }
+
+    override fun onBackPressed() {
+        loginPresenter.skipLogin()
+        super.onBackPressed()
+    }
 }


### PR DESCRIPTION
Fixes #2136

Changes: 
Pressing back button in login page leads to the chat activity now. This was decided in the comments in an old pr.

Screenshots for the change: 
![Uploading ezgif.com-video-to-gif.gif…]()
