### PR TITLE
feat: Implement the feature to redirect to login page to rate skills

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -1,6 +1,7 @@
 package org.fossasia.susi.ai.skills.skilldetails
 
 import android.annotation.SuppressLint
+import android.content.DialogInterface
 import android.content.Intent
 import android.graphics.Color
 import android.net.Uri
@@ -276,9 +277,22 @@ class SkillDetailsFragment : Fragment(), ISkillDetailsView {
                     } else {
                         tv_unrated_skill.text = getString(R.string.skill_unrated_for_anonymous_user)
                         tv_unrated_skill.setOnClickListener {
-                            loginLogoutModulePresenter.logout()
-                            val intent = Intent(requireContext(), LoginActivity::class.java)
-                            startActivity(intent)
+                            val alertBuilder = AlertDialog.Builder(requireContext())
+                            alertBuilder.setMessage(getString(R.string.skill_rate_login_alert))
+                                    .setCancelable(false)
+                                    .setNegativeButton("No", DialogInterface.OnClickListener { dialog, which ->
+                                        dialog.cancel()
+                                    })
+
+                                    .setPositiveButton("Yes", DialogInterface.OnClickListener { dialog, which ->
+                                        loginLogoutModulePresenter.logout()
+                                        val intent = Intent(requireContext(), LoginActivity::class.java)
+                                        startActivity(intent)
+                                    })
+
+                            val alertPrompt = alertBuilder.create()
+                            alertPrompt.setTitle("Rate Skills")
+                            alertPrompt.show()
                         }
                     }
                 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsFragment.kt
@@ -275,6 +275,11 @@ class SkillDetailsFragment : Fragment(), ISkillDetailsView {
                         tv_unrated_skill.text = getString(R.string.skill_unrated)
                     } else {
                         tv_unrated_skill.text = getString(R.string.skill_unrated_for_anonymous_user)
+                        tv_unrated_skill.setOnClickListener {
+                            loginLogoutModulePresenter.logout()
+                            val intent = Intent(requireContext(), LoginActivity::class.java)
+                            startActivity(intent)
+                        }
                     }
                 }
             }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/SkillDetailsPresenter.kt
@@ -4,8 +4,6 @@ import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.data.contract.ISkillDetailsModel
 import org.fossasia.susi.ai.data.SkillDetailsModel
 import org.fossasia.susi.ai.data.UtilModel
-import org.fossasia.susi.ai.data.db.DatabaseRepository
-import org.fossasia.susi.ai.data.db.contract.IDatabaseRepository
 import org.fossasia.susi.ai.dataclasses.FetchFeedbackQuery
 import org.fossasia.susi.ai.dataclasses.PostFeedback
 import org.fossasia.susi.ai.dataclasses.ReportSkillQuery
@@ -15,7 +13,6 @@ import org.fossasia.susi.ai.rest.responses.susi.PostSkillFeedbackResponse
 import org.fossasia.susi.ai.rest.responses.susi.GetSkillFeedbackResponse
 import org.fossasia.susi.ai.rest.responses.susi.ReportSkillResponse
 import org.fossasia.susi.ai.rest.responses.susi.GetRatingByUserResponse
-import org.fossasia.susi.ai.skills.settings.contract.ISettingsView
 import org.fossasia.susi.ai.skills.skilldetails.contract.ISkillDetailsPresenter
 import org.fossasia.susi.ai.skills.skilldetails.contract.ISkillDetailsView
 import retrofit2.Response
@@ -36,8 +33,6 @@ class SkillDetailsPresenter(skillDetailsFragment: SkillDetailsFragment) : ISkill
     private var skillDetailsModel: SkillDetailsModel = SkillDetailsModel()
     private var skillDetailsView: ISkillDetailsView? = null
     private val utilModel: UtilModel = UtilModel(skillDetailsFragment.requireContext())
-    private var databaseRepository: IDatabaseRepository = DatabaseRepository()
-    private var settingView: ISettingsView? = null
 
     override fun onAttach(skillDetailsView: ISkillDetailsView) {
         this.skillDetailsView = skillDetailsView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -523,4 +523,5 @@
     <string name="settings_privacy">Privacy</string>
     <string name="settings_privacy_key">privacy</string>
     <string name="rate_chat">Thank you for responding</string>
+    <string name="skill_rate_login_alert">You need to login to rate skills. Do you want to login now?</string>
 </resources>


### PR DESCRIPTION
Fixes #2126 
Changes: 
If user is not logged in, and he wants to rate a skill. Clicking on rate skill redirects to login page

Screenshots for the change: 
<img width="378" alt="Screenshot 2019-05-28 at 8 27 30 PM" src="https://user-images.githubusercontent.com/43731599/58488494-0d95cd00-8187-11e9-9785-3990b8b71ced.png">
