### PR TITLE
feat: Implement remember me option in login screen

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -154,6 +154,6 @@ dependencies {
     implementation 'com.facebook.shimmer:shimmer:0.4.0'
 
     //Smart LOck authentication
-    implementation 'com.google.android.gms:play-services-auth:16.0.1'
+    implementation "com.google.android.gms:play-services-auth:${rootConfiguration.playServiceAuthVersion}"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${rootConfiguration.kotlinVersion}"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -153,5 +153,7 @@ dependencies {
     //Shimmer
     implementation 'com.facebook.shimmer:shimmer:0.4.0'
 
+    //Smart LOck authentication
+    implementation 'com.google.android.gms:play-services-auth:16.0.1'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${rootConfiguration.kotlinVersion}"
 }

--- a/app/config.gradle
+++ b/app/config.gradle
@@ -23,4 +23,5 @@ ext {
     customTabsVersion = '28.0.0'
     jUnitVersion = '4.12'
     mockitoCoreVersion = '1.10.19'
+    playServiceAuthVersion='16.0.1'
 }

--- a/app/src/main/java/org/fossasia/susi/ai/helper/Constant.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/Constant.kt
@@ -29,6 +29,8 @@ object Constant {
     const val SAVED_EMAIL = "saved_email"
     const val SAVE_EMAIL = "save_email"
 
+    const val SUSI_ACCOUNT = "susi_account"
+
     const val SAVE_DIALOG_STATE = "save_state"
     const val SUSI_SERVER = "is_susi_server_selected"
     const val CUSTOM_SERVER = "custom_server"

--- a/app/src/main/java/org/fossasia/susi/ai/login/contract/ILoginPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/contract/ILoginPresenter.kt
@@ -1,5 +1,7 @@
 package org.fossasia.susi.ai.login.contract
 
+import android.content.Context
+
 /**
  * The interface for Login Presenter
  *
@@ -20,4 +22,8 @@ interface ILoginPresenter {
     fun requestPassword(email: String, url: String, isPersonalServerChecked: Boolean)
 
     fun cancelSignup()
+
+    fun saveCredential(email: String, password: String)
+
+    fun clientRequest(context: Context)
 }

--- a/app/src/main/java/org/fossasia/susi/ai/login/contract/ILoginView.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/contract/ILoginView.kt
@@ -1,5 +1,7 @@
 package org.fossasia.susi.ai.login.contract
 
+import com.google.android.gms.auth.api.credentials.Credential
+
 /**
  * The interface for Login view
  *
@@ -24,4 +26,6 @@ interface ILoginView {
     fun resetPasswordSuccess()
 
     fun resetPasswordFailure(title: String?, message: String?, button: String?, color: Int)
+
+    fun onCredentialRetrieved(credential: Credential?)
 }

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -72,6 +72,13 @@
                 android:layout_marginBottom="5dp"
                 android:text="@string/custom_server" />
 
+            <android.support.v7.widget.AppCompatCheckBox
+                android:id="@+id/rememberCredential"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="@dimen/margin_bottom"
+                android:text="@string/remember_me" />
+
             <android.support.design.widget.TextInputLayout
                 android:id="@+id/inputUrl"
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -63,6 +63,13 @@
             android:layout_marginBottom="@dimen/margin_bottom"
             android:text="@string/custom_server" />
 
+        <android.support.v7.widget.AppCompatCheckBox
+            android:id="@+id/rememberCredential"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="@dimen/margin_bottom"
+            android:text="@string/remember_me" />
+
         <android.support.design.widget.TextInputLayout
             android:id="@+id/inputUrl"
             android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,6 +325,7 @@
     <string name="content_type_static">Content Type: Static</string>
 
     <string name="custom_server">Custom Server</string>
+    <string name="remember_me">Remember Me </string>
 
     <string name="description">Description</string>
     <string name="description_long">Description long</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -325,7 +325,7 @@
     <string name="content_type_static">Content Type: Static</string>
 
     <string name="custom_server">Custom Server</string>
-    <string name="remember_me">Remember Me </string>
+    <string name="remember_me">Remember Me</string>
 
     <string name="description">Description</string>
     <string name="description_long">Description long</string>


### PR DESCRIPTION
Fixes #1301 
Changes:
Users can now save their login credentials using smart lock features (Credential API of google). Credentials are stored only if the user selects the remember me options. If clicked so, it auto fills the fields, next time when the user wants to log in.

Screenshots for the change: 
![sma](https://user-images.githubusercontent.com/43731599/58752599-735bbf00-84cf-11e9-9669-031ae9794932.gif)
