### PR TITLE
fix: Fix smart speaker connectivity problem during different wifi connection of device

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/DeviceConnectPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/DeviceConnectPresenter.kt
@@ -111,9 +111,18 @@ class DeviceConnectPresenter(context: Context, manager: WifiManager) : IDeviceCo
         ConnectWifi().execute()
     }
 
+    override fun disconnectConnectedWifi() {
+        val wm = wifiManager
+        val networkID = wm.connectionInfo.networkId
+        wm.disconnect()
+        wm.removeNetwork(networkID)
+        wm.disableNetwork(networkID)
+    }
+
     inner class ConnectWifi : AsyncTask<Void, Void, Void>() {
 
         override fun doInBackground(vararg p0: Void?): Void? {
+            disconnectConnectedWifi()
             val wifiConfiguration = WifiConfiguration()
             wifiConfiguration.SSID = "\"" + SSID + "\""
             wifiConfiguration.preSharedKey = "\"" + "password" + "\""

--- a/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/contract/IDeviceConnectPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/contract/IDeviceConnectPresenter.kt
@@ -31,4 +31,6 @@ interface IDeviceConnectPresenter {
     fun makeConfigRequest()
 
     fun makeAuthRequest(password: String)
+
+    fun disconnectConnectedWifi()
 }


### PR DESCRIPTION
Fixes #2252 #2249 

Changes:
Users can now connect to the smart speaker, even if his mobile is connected to a wifi network. Also, the app can connect to the smart speaker, if the app tried to connect to the device before (susi.ai hotspot password saved in cache).

Screenshots for the change: 
