### PR TITLE
fix: hotword detection problem after speech recongnition fails

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
@@ -100,6 +100,7 @@ class STTFragment : Fragment() {
                 activity?.searchChat?.show()
                 activity?.voiceSearchChat?.show()
                 activity?.btnSpeak?.isEnabled = true
+                chatPresenter.startHotwordDetection()
                 activity?.supportFragmentManager?.popBackStackImmediate()
             }
 


### PR DESCRIPTION
Fixes #1783 

Changes:
Added Hotword recognition call method even if the speech recognition fails

Screenshots for the change: No relevant change in UI

Apk:
[app-fdroid-debug.apk.zip](https://github.com/fossasia/susi_android/files/3270839/app-fdroid-debug.apk.zip)

