### PR TITLE
feat: Order feedback by date

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/feedback/FeedbackActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/feedback/FeedbackActivity.kt
@@ -5,9 +5,9 @@ import android.support.v7.app.AppCompatActivity
 import android.support.v7.widget.LinearLayoutManager
 import android.view.MenuItem
 import kotlinx.android.synthetic.main.activity_feedback.rvAllFeedback
-import kotlinx.android.synthetic.main.activity_feedback.*
 
 import org.fossasia.susi.ai.R
+import org.fossasia.susi.ai.rest.responses.susi.Feedback
 import org.fossasia.susi.ai.rest.responses.susi.GetSkillFeedbackResponse
 import org.fossasia.susi.ai.skills.feedback.adapters.recycleradapters.AllReviewsAdapter
 /**
@@ -21,13 +21,14 @@ class FeedbackActivity : AppCompatActivity() {
         val actionBar = supportActionBar
         actionBar?.setDisplayHomeAsUpEnabled(true)
         val feedbackResponse: GetSkillFeedbackResponse? = intent.extras.get("feedbackResponse") as GetSkillFeedbackResponse
+        val arrangedFeedbackList: ArrayList<Feedback> = intent.extras.get("arrangedFeedbackList") as ArrayList<Feedback>
         if (feedbackResponse != null) {
             title = feedbackResponse.skillName.capitalize() + " " + getString(R.string.reviews)
-            if (!feedbackResponse.feedbackList.isNullOrEmpty()) {
+            if (!arrangedFeedbackList.isEmpty()) {
                 val layoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
                 rvAllFeedback.setHasFixedSize(true)
                 rvAllFeedback.layoutManager = layoutManager
-                rvAllFeedback.adapter = AllReviewsAdapter(this, feedbackResponse.feedbackList)
+                rvAllFeedback.adapter = AllReviewsAdapter(this, arrangedFeedbackList)
             }
         }
     }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
@@ -58,7 +58,7 @@ class FeedbackAdapter(
             }
         }
 
-        var reverseResponse = feedbackResponse.feedbackList.asReversed()
+        val reverseResponse = feedbackResponse.feedbackList.asReversed()
         reverseResponse.forEach { item ->
             if (item.email != PrefManager.getStringSet(Constant.SAVED_EMAIL)?.iterator()?.next()) {
                 arrangedFeedbackList.add(item)

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
@@ -54,29 +54,27 @@ class FeedbackAdapter(
             arrangedFeedbackList.clear()
             feedbackResponse.feedbackList.forEach { item ->
                 if (item.email == PrefManager.getStringSet(Constant.SAVED_EMAIL)?.iterator()?.next()) {
-                    var feedback = Feedback()
-                    feedback.email = item.email
-                    feedback.userName = item.userName
-                    feedback.avatar = item.avatar
-                    feedback.timestamp = item.timestamp
-                    feedback.feedback = item.feedback
-                    arrangedFeedbackList.add(feedback)
+                    addFeedback(item)
                 }
             }
 
             var reverseResponse = feedbackResponse.feedbackList.asReversed()
             reverseResponse.forEach { item ->
                 if (item.email != PrefManager.getStringSet(Constant.SAVED_EMAIL)?.iterator()?.next()) {
-                    var feedback = Feedback()
-                    feedback.email = item.email
-                    feedback.userName = item.userName
-                    feedback.avatar = item.avatar
-                    feedback.timestamp = item.timestamp
-                    feedback.feedback = item.feedback
-                    arrangedFeedbackList.add(feedback)
+                    addFeedback(item)
                 }
             }
         Timber.d("Arranged the feedback")
+    }
+
+    private fun addFeedback(item: Feedback) {
+        var feedback = Feedback()
+        feedback.email = item.email
+        feedback.userName = item.userName
+        feedback.avatar = item.avatar
+        feedback.timestamp = item.timestamp
+        feedback.feedback = item.feedback
+        arrangedFeedbackList.add(feedback)
     }
 
     @NonNull

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
@@ -54,27 +54,17 @@ class FeedbackAdapter(
             arrangedFeedbackList.clear()
             feedbackResponse.feedbackList.forEach { item ->
                 if (item.email == PrefManager.getStringSet(Constant.SAVED_EMAIL)?.iterator()?.next()) {
-                    addFeedback(item)
+                    arrangedFeedbackList.add(item)
                 }
             }
 
             var reverseResponse = feedbackResponse.feedbackList.asReversed()
             reverseResponse.forEach { item ->
                 if (item.email != PrefManager.getStringSet(Constant.SAVED_EMAIL)?.iterator()?.next()) {
-                    addFeedback(item)
+                    arrangedFeedbackList.add(item)
                 }
             }
         Timber.d("Arranged the feedback")
-    }
-
-    private fun addFeedback(item: Feedback) {
-        var feedback = Feedback()
-        feedback.email = item.email
-        feedback.userName = item.userName
-        feedback.avatar = item.avatar
-        feedback.timestamp = item.timestamp
-        feedback.feedback = item.feedback
-        arrangedFeedbackList.add(feedback)
     }
 
     @NonNull

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
@@ -30,7 +30,7 @@ class FeedbackAdapter(
         RecyclerView.Adapter<FeedbackViewHolder>(), FeedbackViewHolder.ClickListener {
 
     private val clickListener: FeedbackViewHolder.ClickListener = this
-    var arrangedFeedbackList: ArrayList<Feedback> = ArrayList()
+    private val arrangedFeedbackList: ArrayList<Feedback> = ArrayList()
 
     @NonNull
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): FeedbackViewHolder {
@@ -53,14 +53,14 @@ class FeedbackAdapter(
     private fun arrangeFeedbacks() {
         arrangedFeedbackList.clear()
         feedbackResponse.feedbackList.forEach { item ->
-            if (item.email == PrefManager.getString(Constant.SAVED_EMAIL, "")) {
+            if (item.email == PrefManager.getStringSet(Constant.SAVED_EMAIL)?.iterator()?.next()) {
                 arrangedFeedbackList.add(item)
             }
         }
 
         var reverseResponse = feedbackResponse.feedbackList.asReversed()
         reverseResponse.forEach { item ->
-            if (item.email != PrefManager.getString(Constant.SAVED_EMAIL, "")) {
+            if (item.email != PrefManager.getStringSet(Constant.SAVED_EMAIL)?.iterator()?.next()) {
                 arrangedFeedbackList.add(item)
             }
         }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
@@ -51,19 +51,19 @@ class FeedbackAdapter(
     }
 
     private fun arrangeFeedbacks() {
-            arrangedFeedbackList.clear()
-            feedbackResponse.feedbackList.forEach { item ->
-                if (item.email == PrefManager.getStringSet(Constant.SAVED_EMAIL)?.iterator()?.next()) {
-                    arrangedFeedbackList.add(item)
-                }
+        arrangedFeedbackList.clear()
+        feedbackResponse.feedbackList.forEach { item ->
+            if (item.email == PrefManager.getString(Constant.SAVED_EMAIL, "")) {
+                arrangedFeedbackList.add(item)
             }
+        }
 
-            var reverseResponse = feedbackResponse.feedbackList.asReversed()
-            reverseResponse.forEach { item ->
-                if (item.email != PrefManager.getStringSet(Constant.SAVED_EMAIL)?.iterator()?.next()) {
-                    arrangedFeedbackList.add(item)
-                }
+        var reverseResponse = feedbackResponse.feedbackList.asReversed()
+        reverseResponse.forEach { item ->
+            if (item.email != PrefManager.getString(Constant.SAVED_EMAIL, "")) {
+                arrangedFeedbackList.add(item)
             }
+        }
         Timber.d("Arranged the feedback")
     }
 

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
@@ -76,7 +76,7 @@ class FeedbackAdapter(
                     arrangedFeedbackList.add(feedback)
                 }
             }
-        Timber.d("Arranged the feedbacks")
+        Timber.d("Arranged the feedback")
     }
 
     @NonNull


### PR DESCRIPTION
Fixes #2023 #1453 

Changes: 
The feedback is now ordered in a way such that, if the user has feedback, then it gets displayed at the top and the rests are ordered by the newest first.


Screenshots for the change: 
![WhatsApp Image 2019-06-13 at 12 16 25 AM](https://user-images.githubusercontent.com/43731599/59378220-711c1f00-8d71-11e9-9b2a-b9bc48e3a738.jpeg)


Apk: 
[app-fdroid-debug.apk.zip](https://github.com/fossasia/susi_android/files/3282758/app-fdroid-debug.apk.zip)

