### PR TITLE
fix: Run speech recognition in default language

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
@@ -20,6 +20,7 @@ import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.chat.adapters.recycleradapters.VoiceCommandsAdapter
 import org.fossasia.susi.ai.chat.contract.IChatPresenter
 import timber.log.Timber
+import java.util.Locale
 
 /**
  * Created by meeera on 17/8/17.
@@ -56,6 +57,7 @@ class STTFragment : Fragment() {
                 RecognizerIntent.LANGUAGE_MODEL_FREE_FORM)
         intent.putExtra(RecognizerIntent.EXTRA_CALLING_PACKAGE,
                 "com.domain.app")
+        intent.putExtra(RecognizerIntent.EXTRA_LANGUAGE, Locale.getDefault())
         intent.putExtra(RecognizerIntent.EXTRA_PARTIAL_RESULTS, true)
         intent.putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_POSSIBLY_COMPLETE_SILENCE_LENGTH_MILLIS, 5000)
         intent.putExtra(RecognizerIntent.EXTRA_SPEECH_INPUT_COMPLETE_SILENCE_LENGTH_MILLIS, 5000)


### PR DESCRIPTION
Fixes #1739 

Changes: 
Now the intent speech recognition runs through the default language of the system.

Screenshots for the change: 
![WhatsApp Image 2019-06-13 at 1 23 33 AM](https://user-images.githubusercontent.com/43731599/59382108-8d708980-8d7a-11e9-9518-b26e24cb0698.jpeg)
