### PR TITLE
feat: Show wifi password layout

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/DeviceConnectFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/DeviceConnectFragment.kt
@@ -47,6 +47,7 @@ import kotlinx.android.synthetic.main.fragment_device_connect.room_wizard
 import kotlinx.android.synthetic.main.fragment_device_connect.password_layout
 import kotlinx.android.synthetic.main.fragment_device_connect.account_wizard
 import kotlinx.android.synthetic.main.fragment_device_connect.success_setup_screen
+import kotlinx.android.synthetic.main.fragment_device_connect.wifi_password_layout
 import kotlinx.android.synthetic.main.password_layout.account_auth_password_input
 import kotlinx.android.synthetic.main.password_layout.password_finish
 import kotlinx.android.synthetic.main.password_layout.anonymous_mode
@@ -55,6 +56,10 @@ import kotlinx.android.synthetic.main.room_layout.edt_room
 import kotlinx.android.synthetic.main.room_layout.add_room
 import kotlinx.android.synthetic.main.room_layout.room_next
 import kotlinx.android.synthetic.main.room_layout.room_previous
+import kotlinx.android.synthetic.main.wifi_password_layout.wifi_next
+import kotlinx.android.synthetic.main.wifi_password_layout.wifi_previous
+import kotlinx.android.synthetic.main.wifi_password_layout.wifi_name_show
+import kotlinx.android.synthetic.main.wifi_password_layout.wifi_password_input
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.data.model.RoomsAvailable
 import org.fossasia.susi.ai.device.DeviceActivity
@@ -131,7 +136,9 @@ class DeviceConnectFragment : Fragment(), IDeviceConnectView {
         scanHelp.visibility = View.GONE
         showWifiList = false
         addDeviceButton.visibility = View.GONE
+        scanHelp.visibility = View.GONE
         deviceList.visibility = View.GONE
+        wifi_password_layout.visibility = View.GONE
         wifiList.visibility = View.GONE
         connect_wizard.background = ContextCompat.getDrawable(requireContext(), R.drawable.border_blue)
         wifi_wizard.background = ContextCompat.getDrawable(requireContext(), R.drawable.border_normal)
@@ -163,7 +170,9 @@ class DeviceConnectFragment : Fragment(), IDeviceConnectView {
         room.visibility = View.GONE
         showWifiList = true
         connection_susiai_main_screen.visibility = View.GONE
+        wifi_password_layout.visibility = View.GONE
         showWifi.visibility = View.VISIBLE
+        scanHelp.visibility = View.VISIBLE
         room_wizard.background = ContextCompat.getDrawable(requireContext(), R.drawable.border_normal)
         room_wizard.setTextColor(Color.BLACK)
         wifi_wizard.background = ContextCompat.getDrawable(requireContext(), R.drawable.border_blue)
@@ -182,6 +191,28 @@ class DeviceConnectFragment : Fragment(), IDeviceConnectView {
                 }).setTitle(title).create().show()
     }
 
+    // Prompt password for selected wifi
+    override fun selectedWifi(wifiName: String) {
+        addDeviceButton.visibility = View.GONE
+        deviceList.visibility = View.GONE
+        wifiList.visibility = View.GONE
+        password_layout.visibility = View.GONE
+        showWifiList = false
+        connection_susiai_main_screen.visibility = View.GONE
+        showWifi.visibility = View.GONE
+        scanHelp.visibility = View.GONE
+        wifi_password_layout.visibility = View.VISIBLE
+        wifi_name_show.text = wifiName
+
+        wifi_previous.setOnClickListener {
+            connectionMainScreen()
+        }
+
+        wifi_next.setOnClickListener {
+            deviceConnectPresenter.makeWifiRequest(wifiName, wifi_password_input.text.toString())
+        }
+    }
+
     // Function to show available rooms in the 3rd step
     override fun rooms() {
         stopProgress()
@@ -189,6 +220,7 @@ class DeviceConnectFragment : Fragment(), IDeviceConnectView {
         addDeviceButton.visibility = View.GONE
         deviceList.visibility = View.GONE
         wifiList.visibility = View.GONE
+        wifi_password_layout.visibility = View.GONE
         password_layout.visibility = View.GONE
         showWifiList = false
         connection_susiai_main_screen.visibility = View.GONE

--- a/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/DeviceConnectFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/DeviceConnectFragment.kt
@@ -52,6 +52,7 @@ import kotlinx.android.synthetic.main.password_layout.account_auth_password_inpu
 import kotlinx.android.synthetic.main.password_layout.password_finish
 import kotlinx.android.synthetic.main.password_layout.anonymous_mode
 import kotlinx.android.synthetic.main.password_layout.password_previous
+import kotlinx.android.synthetic.main.password_layout.account_email
 import kotlinx.android.synthetic.main.room_layout.edt_room
 import kotlinx.android.synthetic.main.room_layout.add_room
 import kotlinx.android.synthetic.main.room_layout.room_next
@@ -69,6 +70,8 @@ import org.fossasia.susi.ai.device.deviceconnect.adapters.recycleradapters.Devic
 import org.fossasia.susi.ai.device.deviceconnect.adapters.recycleradapters.RoomsAdapter
 import org.fossasia.susi.ai.device.deviceconnect.contract.IDeviceConnectPresenter
 import org.fossasia.susi.ai.device.deviceconnect.contract.IDeviceConnectView
+import org.fossasia.susi.ai.helper.Constant
+import org.fossasia.susi.ai.helper.PrefManager
 import org.fossasia.susi.ai.helper.Utils
 import org.fossasia.susi.ai.skills.SkillsActivity
 import org.fossasia.susi.ai.skills.SkillsActivity.Companion.REDIRECTED_FROM
@@ -264,6 +267,7 @@ class DeviceConnectFragment : Fragment(), IDeviceConnectView {
     // Final step of connectivity
     override fun passwordLayoutSetup() {
         password_layout.visibility = View.VISIBLE
+        account_email.text = PrefManager.getStringSet(Constant.SAVED_EMAIL)?.iterator()?.next()
         room.visibility = View.GONE
         room_wizard.background = ContextCompat.getDrawable(requireContext(), R.drawable.border_blue)
         account_wizard.background = ContextCompat.getDrawable(requireContext(), R.drawable.border_blue)

--- a/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/DeviceConnectPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/DeviceConnectPresenter.kt
@@ -83,6 +83,10 @@ class DeviceConnectPresenter(context: Context, manager: WifiManager) : IDeviceCo
         return false
     }
 
+    override fun selectedWifi(wifiName: String) {
+        deviceConnectView?.selectedWifi(wifiName)
+    }
+
     override fun addRoom(room: String) {
         realm = Realm.getDefaultInstance()
         realm.beginTransaction()
@@ -155,10 +159,6 @@ class DeviceConnectPresenter(context: Context, manager: WifiManager) : IDeviceCo
         wm.disableNetwork(networkID)
     }
 
-    override fun initialSetup() {
-        deviceConnectView?.connectionMainScreen()
-    }
-
     inner class ConnectWifi : AsyncTask<Void, Void, Void>() {
 
         override fun doInBackground(vararg p0: Void?): Void? {
@@ -209,7 +209,6 @@ class DeviceConnectPresenter(context: Context, manager: WifiManager) : IDeviceCo
     override fun onSendCredentialFailure(localMessage: String) {
         Timber.d("WIFI - FAILURE")
         deviceConnectView?.stopProgress()
-        // deviceConnectView?.onDeviceConnectionError(utilModel.getString(R.string.wifi_error), localMessage)
         deviceConnectView?.wifiSetup()
         deviceConnectView?.showDialog(utilModel.getString(R.string.wifi_error), utilModel.getString(R.string.wifi_connection_failed))
     }

--- a/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/adapters/viewholders/WifiViewHolder.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/adapters/viewholders/WifiViewHolder.kt
@@ -1,15 +1,10 @@
 package org.fossasia.susi.ai.device.deviceconnect.adapters.viewholders
 
-import android.support.v7.app.AlertDialog
 import android.support.v7.widget.RecyclerView
-import android.view.LayoutInflater
 import android.view.View
-import android.widget.EditText
 import android.widget.LinearLayout
 import android.widget.TextView
-
 import org.fossasia.susi.ai.R
-import org.fossasia.susi.ai.data.UtilModel
 import org.fossasia.susi.ai.device.deviceconnect.DeviceConnectPresenter
 
 import kotterknife.bindView
@@ -26,22 +21,6 @@ class WifiViewHolder(itemView: View, private var devicePresenter: DeviceConnectP
     }
 
     fun onClick() {
-        val utilModel = UtilModel(itemView.context)
-        val view = LayoutInflater.from(itemView.context).inflate(R.layout.get_password, null)
-        val alertDialog = AlertDialog.Builder(itemView.context).create()
-        alertDialog.setTitle(utilModel.getString(R.string.enter_password) + wifiName.text.toString())
-        alertDialog.setCancelable(false)
-
-        val password = view.findViewById<EditText>(R.id.edt_pass)
-
-        alertDialog.setButton(AlertDialog.BUTTON_POSITIVE, utilModel.getString(R.string.next)) { dialog, which -> devicePresenter.makeWifiRequest(wifiName.text.toString(), password.text.toString()) }
-
-        alertDialog.setButton(AlertDialog.BUTTON_NEGATIVE, utilModel.getString(R.string.previous)) { dialog, which ->
-            alertDialog.dismiss()
-            devicePresenter.initialSetup()
-        }
-
-        alertDialog.setView(view)
-        alertDialog.show()
+        devicePresenter.selectedWifi(wifiName.text.toString())
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/contract/IDeviceConnectPresenter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/contract/IDeviceConnectPresenter.kt
@@ -38,9 +38,9 @@ interface IDeviceConnectPresenter {
 
     fun getSUSIAIConnectionInfo(): Boolean
 
-    fun initialSetup()
-
     fun selectedRoom(roomName: String?)
 
     fun makeAddRoomRequest(room_name: String)
+
+    fun selectedWifi(wifiName: String)
 }

--- a/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/contract/IDeviceConnectView.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/device/deviceconnect/contract/IDeviceConnectView.kt
@@ -41,4 +41,6 @@ interface IDeviceConnectView {
     fun finishSetup()
 
     fun successSetup()
+
+    fun selectedWifi(wifiName: String)
 }

--- a/app/src/main/res/layout/fragment_device_connect.xml
+++ b/app/src/main/res/layout/fragment_device_connect.xml
@@ -178,4 +178,9 @@
         layout="@layout/finish_setup_layout"
         android:visibility="gone" />
 
+    <include
+        android:id="@+id/wifi_password_layout"
+        layout="@layout/wifi_password_layout"
+        android:visibility="gone" />
+
 </android.support.constraint.ConstraintLayout>

--- a/app/src/main/res/layout/password_layout.xml
+++ b/app/src/main/res/layout/password_layout.xml
@@ -21,6 +21,15 @@
             android:text="@string/password_title"
             android:textSize="@dimen/text_size_large" />
 
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/margin_extra_large"
+            android:layout_marginBottom="@dimen/margin_extra_large"
+            android:padding="@dimen/margin_large"
+            android:id="@+id/account_email"
+            android:textSize="@dimen/text_size_large"/>
+
         <android.support.design.widget.TextInputLayout
             android:id="@+id/account_auth_password"
             android:layout_width="match_parent"

--- a/app/src/main/res/layout/wifi_password_layout.xml
+++ b/app/src/main/res/layout/wifi_password_layout.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="3"
+        android:gravity="center"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_margin="@dimen/margin_extra_large"
+            android:gravity="center"
+            android:text="@string/enter_wifi_password"
+            android:textSize="@dimen/text_size_extra_extra_large" />
+
+        <TextView
+            android:id="@+id/wifi_name_show"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:layout_margin="@dimen/margin_large"
+            android:gravity="center"
+            android:textSize="@dimen/text_size_large" />
+
+        <android.support.design.widget.TextInputLayout
+            android:id="@+id/wifi_password"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="@dimen/margin_moderate"
+            app:errorEnabled="true"
+            app:passwordToggleEnabled="true">
+
+            <android.support.design.widget.TextInputEditText
+                android:id="@+id/wifi_password_input"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/password"
+                android:imeOptions="actionGo"
+                android:inputType="textPassword" />
+        </android.support.design.widget.TextInputLayout>
+    </LinearLayout>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_gravity="center|bottom"
+        android:layout_marginBottom="@dimen/margin_large"
+        android:layout_weight="1"
+        android:orientation="horizontal">
+
+        <Button
+            android:id="@+id/wifi_previous"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom"
+            android:layout_marginLeft="@dimen/margin_moderate"
+            android:layout_marginRight="@dimen/margin_extremely_large"
+            android:layout_weight="1"
+            android:background="@color/colorPrimary"
+            android:text="@string/previous"
+            android:textAllCaps="false"
+            android:textColor="@color/md_white_1000"
+            android:textSize="@dimen/text_size_medium" />
+
+        <Button
+            android:id="@+id/wifi_next"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal|bottom"
+            android:layout_marginLeft="@dimen/margin_extremely_large"
+            android:layout_marginRight="@dimen/margin_moderate"
+            android:layout_weight="1"
+            android:background="@color/colorPrimary"
+            android:text="@string/next"
+            android:textAllCaps="false"
+            android:textColor="@color/md_white_1000"
+            android:textSize="@dimen/text_size_medium" />
+
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -312,6 +312,7 @@
     <string name="error_adding_room_title">Adding Room Failed</string>
     <string name="device_setting_up">Setting up your device</string>
     <string name="susi_ai_hotspot" translatable="false">SUSI.AI</string>
+    <string name="enter_wifi_password">Enter Wi-Fi password</string>
     
     <!-- Device Setup Screen -->
     <string name="connect">1. Connect</string>


### PR DESCRIPTION
Fixes #2306 

Changes:
Instead of the alert dialog box, now we have a layout to enter a password for the wifi. This is similar to the one present in Google Home.

Screenshots for the change: 
<img width="404" alt="Screenshot 2019-07-16 at 4 15 36 PM" src="https://user-images.githubusercontent.com/43731599/61288546-f9fcff00-a7e4-11e9-8496-a36e0dbbda6a.png">
<img width="387" alt="Screenshot 2019-07-16 at 4 15 42 PM" src="https://user-images.githubusercontent.com/43731599/61288566-05502a80-a7e5-11e9-9c8b-b7553eaff486.png">
