### PR TITLE
feat: Update url to show display of connected devices

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/rest/services/SusiService.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/rest/services/SusiService.kt
@@ -189,7 +189,7 @@ interface SusiService {
     @GET("/aaa/addNewDevice.json")
     fun addSusiDevices(@QueryMap query: Map<String, String>): Call<GetAddDeviceResponse>
 
-    @get:GET("/aaa/listUserSettings.json")
+    @get:GET("/aaa/listUserDevices.json")
     val getConnectedDevices: Call<ConnectedDevicesResponse>
 
     /**


### PR DESCRIPTION
Fixes #2314

Changes: 
* Just change the URL by using which we fetch the list of connected devices. Rest everything remains the same.

Screenshots for the change: 
<img width="453" alt="Screenshot 2019-07-22 at 6 56 52 PM" src="https://user-images.githubusercontent.com/43731599/61636055-7d6d9300-acb2-11e9-930a-fd59238a0d5b.png">

