### PR TITLE
fix: Fix margin and paddings in Manage Device page

### DIFF
--- a/app/src/main/res/layout/fragment_music_servers.xml
+++ b/app/src/main/res/layout/fragment_music_servers.xml
@@ -16,7 +16,9 @@
     <android.support.v7.widget.CardView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="@dimen/margin_moderate"
+        android:layout_marginTop="@dimen/margin_large"
+        android:layout_marginStart="@dimen/margin_large"
+        android:layout_marginEnd="@dimen/margin_large"
         android:padding="@dimen/padding_medium">
 
         <LinearLayout


### PR DESCRIPTION
Fixes #2366 

Changes: Made margin uniform in all views in manage devices fragment.

Screenshots for the change: 

<img src="https://user-images.githubusercontent.com/31350501/65021127-28659a80-d94c-11e9-857a-3b6010304341.jpg" alt="drawing" width="250"/>

