### PR TITLE
fix: Set search as IME action and allowing single line text in search box on Chat activity

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/ChatActivity.kt
@@ -197,7 +197,7 @@ class ChatActivity : AppCompatActivity(), IChatView {
             if (keyCode == KeyEvent.KEYCODE_ENTER && event.action == KeyEvent.ACTION_UP && chatSearchInput?.text.toString().isNotEmpty()) {
                 performSearch(chatSearchInput?.text.toString())
             }
-            true
+            false
         }
         chatSearchInput?.requestFocus()
         val inputMethodManager = getSystemService(Context.INPUT_METHOD_SERVICE) as InputMethodManager

--- a/app/src/main/res/layout/activity_chat.xml
+++ b/app/src/main/res/layout/activity_chat.xml
@@ -32,7 +32,9 @@
             android:visibility="invisible"
             android:paddingLeft="@dimen/padding_moderate"
             android:background="@color/colorPrimaryDark"
-            android:textSize="@dimen/text_size_normal"/>
+            android:textSize="@dimen/text_size_normal"
+            android:singleLine="true"
+            android:imeOptions="actionSearch"/>
 
         <android.support.design.widget.FloatingActionButton
             android:id="@+id/searchChat"


### PR DESCRIPTION
Fixes #2394, Chat activity search box changes,

 - Allowing single line search text
 - set actionSearch as ime option for soft input

Screenshots for the change: 

![GIF-191118_114956](https://user-images.githubusercontent.com/1143971/69212582-c7df1d80-0b87-11ea-9643-ae7d18fc1732.gif)
