### PR TITLE
fix: Keyboard does not hide when search is cancelled

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
@@ -141,6 +141,7 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
             overridePendingTransition(R.anim.trans_right_in, R.anim.trans_right_out)
         } else {
             val action = supportActionBar
+            hideSoftKeyboard(this, window.decorView)
             action?.setDisplayShowCustomEnabled(false)
             action?.setDisplayShowTitleEnabled(true)
             searchAction?.icon = resources.getDrawable(R.drawable.ic_open_search)


### PR DESCRIPTION
Fixes #2456 

Changed SkillsActivity's onBackPressed to hide keyboard when back button is pressed.

Before:
![bugearlier](https://user-images.githubusercontent.com/26327688/72547297-651db000-38b2-11ea-889d-f0e480ee179f.gif)


Now:
![fixednow](https://user-images.githubusercontent.com/26327688/72547303-6949cd80-38b2-11ea-9d08-9a8d5d4a34a1.gif)




