### PR TITLE
fix: Shimmer layout appears when switching back to SkillListingFragment

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilllisting/SkillListingFragment.kt
@@ -137,5 +137,8 @@ class SkillListingFragment : Fragment(), ISkillListingView, SwipeRefreshLayout.O
     override fun onResume() {
         super.onResume()
         activity?.title = getString(R.string.skills_activity)
+        if (skills.isNotEmpty()) {
+            shimmer_view_container.visibility = View.GONE
+        }
     }
 }


### PR DESCRIPTION
Fixes #2438 

Changes: Added a check in onResume that when skills list is not empty hide shimmer.

Screenshots for the change: 
<a href="https://imgflip.com/gif/3n3v2a"><img src="https://i.imgflip.com/3n3v2a.gif" title="made at imgflip.com"/></a>
