### PR TITLE
fix: #2435 Login and signup button enabe/disable

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/login/LoginActivity.kt
@@ -6,13 +6,18 @@ import android.app.ProgressDialog
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
+import android.support.design.widget.TextInputEditText
 import android.support.v7.app.AppCompatActivity
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.View
 import android.view.inputmethod.EditorInfo
-import android.widget.ArrayAdapter
-import android.widget.Toast
+import android.widget.*
 import com.google.android.gms.auth.api.credentials.Credential
 import kotlinx.android.synthetic.main.activity_login.*
+import kotlinx.android.synthetic.main.activity_login.password
+import kotlinx.android.synthetic.main.alert_reset_password.*
+import kotlinx.android.synthetic.main.item_susi_message.view.*
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.chat.ChatActivity
 import org.fossasia.susi.ai.helper.AlertboxHelper
@@ -54,6 +59,11 @@ class LoginActivity : AppCompatActivity(), ILoginView {
             }
         }
 
+        //text watcher for all input
+        emailInput.addTextChangedListener(LoginTextWatcher)
+        passwordInput.addTextChangedListener(LoginTextWatcher)
+
+
         progressDialog = ProgressDialog(this)
         progressDialog.setCancelable(false)
         progressDialog.setMessage(getString(R.string.login))
@@ -77,8 +87,23 @@ class LoginActivity : AppCompatActivity(), ILoginView {
         loginPresenter.clientRequest(this)
     }
 
-    override fun onCredentialRetrieved(credential: Credential?) {
 
+    //text watcher object
+    var LoginTextWatcher = object : TextWatcher{
+        override fun afterTextChanged(s: Editable?) {
+        }
+        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+
+        }
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+            val stringEmail = emailInput.text.toString()
+            val stringPassword = passwordInput.text.toString()
+            logIn.setEnabled(stringEmail.isNotEmpty()&&stringPassword.isNotEmpty())
+        }
+    }
+
+
+    override fun onCredentialRetrieved(credential: Credential?) {
         var accountName = credential?.name
         if (accountName == Constant.SUSI_ACCOUNT) {
             email.editText?.setText(credential?.id.toString())

--- a/app/src/main/java/org/fossasia/susi/ai/signup/SignUpActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/signup/SignUpActivity.kt
@@ -8,10 +8,17 @@ import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
 import android.support.v7.app.AppCompatActivity
+import android.text.Editable
+import android.text.TextWatcher
 import android.view.MenuItem
 import android.view.View
 import android.widget.Toast
+import kotlinx.android.synthetic.main.activity_login.*
 import kotlinx.android.synthetic.main.activity_sign_up.*
+import kotlinx.android.synthetic.main.activity_sign_up.email
+import kotlinx.android.synthetic.main.activity_sign_up.password
+import kotlinx.android.synthetic.main.activity_sign_up.signUp
+import kotlinx.android.synthetic.main.alert_reset_password.*
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.chat.ChatActivity
 import org.fossasia.susi.ai.helper.AlertboxHelper
@@ -59,6 +66,12 @@ class SignUpActivity : AppCompatActivity(), ISignUpView {
             }
         }
 
+        //ext watcher for all input
+        signUpEmailInput.addTextChangedListener(SignUpTextWatcher)
+        signUpPasswordInput.addTextChangedListener(SignUpTextWatcher)
+        signUpConfirmPasswordInput.addTextChangedListener(SignUpTextWatcher)
+
+
         val bundle = intent.extras
         val string = bundle?.getString("email")
         if (string != null)
@@ -79,6 +92,21 @@ class SignUpActivity : AppCompatActivity(), ISignUpView {
         signUpPresenter = SignUpPresenter(this)
         signUpPresenter.onAttach(this)
     }
+
+    //text watcher object
+    var SignUpTextWatcher = object: TextWatcher {
+        override fun afterTextChanged(s: Editable?) {
+        }
+        override fun beforeTextChanged(s: CharSequence?, start: Int, count: Int, after: Int) {
+        }
+        override fun onTextChanged(s: CharSequence?, start: Int, before: Int, count: Int) {
+            val stringEmail = signUpEmailInput.text.toString()
+            val stringPassword = signUpPasswordInput.text.toString()
+            var stringConfirmPassword = signUpConfirmPasswordInput.text.toString()
+            signUp.setEnabled(stringEmail.isNotEmpty()&&stringPassword.isNotEmpty()&&stringConfirmPassword.isNotEmpty())
+        }
+    }
+
 
     private fun addListeners() {
         showURL()

--- a/app/src/main/res/drawable/rounded_button_blue.xml
+++ b/app/src/main/res/drawable/rounded_button_blue.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/md_blue_300" />
+    <corners android:radius="5dp" />
+</shape>

--- a/app/src/main/res/layout-land/activity_login.xml
+++ b/app/src/main/res/layout-land/activity_login.xml
@@ -98,8 +98,9 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
-                android:background="@drawable/rounded_button"
-                android:text="@string/activity_login_log_in" />
+                android:background="@drawable/rounded_button_blue"
+                android:text="@string/activity_login_log_in"
+                android:enabled="false"/>
 
             <TextView
                 android:id="@+id/forgotPassword"

--- a/app/src/main/res/layout-land/activity_sign_up.xml
+++ b/app/src/main/res/layout-land/activity_sign_up.xml
@@ -101,8 +101,9 @@
             android:layout_width="@dimen/activity_landscape_width"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_large"
-            android:background="@drawable/rounded_button"
-            android:text="@string/sign_up" />
+            android:background="@drawable/rounded_button_blue"
+            android:text="@string/sign_up"
+            android:enabled="false"/>
 
         <TextView
             android:id="@+id/signUpToLogin"

--- a/app/src/main/res/layout/activity_login.xml
+++ b/app/src/main/res/layout/activity_login.xml
@@ -89,11 +89,12 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center"
-            android:layout_marginBottom="@dimen/margin_medium"
             android:layout_marginTop="@dimen/margin_medium"
-            android:background="@drawable/rounded_button"
+            android:layout_marginBottom="@dimen/margin_medium"
+            android:background="@drawable/rounded_button_blue"
             android:padding="@dimen/cmv_padding"
-            android:text="@string/activity_login_log_in" />
+            android:text="@string/activity_login_log_in"
+            android:enabled="false"/>
 
         <TextView
             android:id="@+id/forgotPassword"

--- a/app/src/main/res/layout/activity_sign_up.xml
+++ b/app/src/main/res/layout/activity_sign_up.xml
@@ -35,6 +35,7 @@
             app:errorEnabled="true">
 
             <android.support.design.widget.TextInputEditText
+                android:id="@+id/signUpEmailInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/email"
@@ -52,6 +53,7 @@
             app:passwordToggleEnabled="true">
 
             <android.support.design.widget.TextInputEditText
+                android:id="@+id/signUpPasswordInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/password"
@@ -69,6 +71,7 @@
             app:passwordToggleEnabled="true">
 
             <android.support.design.widget.TextInputEditText
+                android:id="@+id/signUpConfirmPasswordInput"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:hint="@string/confirm_password"
@@ -110,8 +113,9 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_marginTop="@dimen/margin_large"
-            android:background="@drawable/rounded_button"
-            android:text="@string/sign_up" />
+            android:background="@drawable/rounded_button_blue"
+            android:text="@string/sign_up"
+            android:enabled="false"/>
 
         <TextView
             android:id="@+id/signUpToLogin"


### PR DESCRIPTION
fix: #2435 login and signup button get enable and disable according to the input of credentials

Changes:  Until the email id and password is filled up the Login/Sign Up button will remain disabled and fade in colour

### **Screenshots for the change:** 
_login page-_
![WhatsApp Image 2020-01-27 at 3 05 20 PM](https://user-images.githubusercontent.com/35365450/73163994-0d374280-4117-11ea-81a1-46068346ff13.jpeg)

![WhatsApp Image 2020-01-27 at 3 05 20 PM (4)](https://user-images.githubusercontent.com/35365450/73164101-4079d180-4117-11ea-9dfe-f994e0f449e4.jpeg)

_Signup page-_

![WhatsApp Image 2020-01-27 at 3 05 20 PM (2)](https://user-images.githubusercontent.com/35365450/73164118-48d20c80-4117-11ea-86ed-a2e332f6cb1a.jpeg)

![WhatsApp Image 2020-01-27 at 3 05 20 PM (1)](https://user-images.githubusercontent.com/35365450/73164121-4bccfd00-4117-11ea-8aff-dc410694cb6a.jpeg)



