### PR TITLE
fix: Livedata and databinding added in GroupWiseSkillsFragment

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,12 +14,16 @@ apply plugin: 'realm-android'
 
 def YOUTUBE_API_KEY = System.getenv('YOUTUBE_API_KEY') ?: "YOUR_API_KEY"
 //noinspection SpellCheckingInspection
-def MAPBOX_API_KEY = '"'+System.getenv('MAPBOX_API_KEY')+'"' ?: '"DEFAULT"'
+def MAPBOX_API_KEY = '"' + System.getenv('MAPBOX_API_KEY') + '"' ?: '"DEFAULT"'
 
 def LOCAL_KEY_PRESENT = project.hasProperty('SIGNING_KEY_FILE') && rootProject.file(SIGNING_KEY_FILE).exists()
 
 android {
     compileSdkVersion rootConfiguration.compileSdkVersion
+
+    dataBinding {
+        enabled true
+    }
 
     defaultConfig {
         applicationId "ai.susi"

--- a/app/src/main/java/org/fossasia/susi/ai/helper/ListHelper.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/ListHelper.kt
@@ -1,0 +1,9 @@
+package org.fossasia.susi.ai.helper
+
+import org.fossasia.susi.ai.rest.responses.susi.SkillData
+
+object ListHelper {
+    fun revertList(list: List<SkillData>): List<SkillData> {
+        return list.reversed()
+    }
+}

--- a/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/SkillsActivity.kt
@@ -203,12 +203,12 @@ class SkillsActivity : AppCompatActivity(), SkillFragmentCallback {
             R.id.menu_ascending -> {
                 FILTER_NAME = Constant.ASCENDING
                 invalidateOptionsMenu()
-                groupWiseSkillsFragment.onRefresh()
+                groupWiseSkillsFragment.revertSkillList()
             }
             R.id.menu_descending -> {
                 FILTER_NAME = Constant.DESCENDING
                 invalidateOptionsMenu()
-                groupWiseSkillsFragment.onRefresh()
+                groupWiseSkillsFragment.revertSkillList()
             }
             R.id.menu_a_to_z -> {
                 FILTER_TYPE = Constant.NEW_A_TO_Z

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skillSearch/SearchSkillFragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skillSearch/SearchSkillFragment.kt
@@ -3,6 +3,7 @@ package org.fossasia.susi.ai.skills.skillSearch
 import android.content.Context
 import android.os.Bundle
 import android.support.annotation.NonNull
+import android.support.design.widget.FloatingActionButton
 import android.support.v4.app.Fragment
 import android.support.v4.widget.SwipeRefreshLayout
 import android.support.v7.widget.LinearLayoutManager
@@ -10,6 +11,7 @@ import android.support.v7.widget.SnapHelper
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import kotlinx.android.synthetic.main.fragment_group_wise_skill_listing.*
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.dataclasses.GroupWiseSkills
@@ -51,7 +53,12 @@ class SearchSkillFragment : Fragment(), IGroupWiseSkillsView, SwipeRefreshLayout
     }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
-        return inflater.inflate(R.layout.fragment_group_wise_skill_listing, container, false)
+        var v = inflater.inflate(R.layout.fragment_group_wise_skill_listing, container, false)
+        var searchEditText = v.findViewById<EditText>(R.id.skillWiseSearchEdit)
+        searchEditText.visibility = View.GONE
+        var searchFab = v.findViewById<FloatingActionButton>(R.id.searchSkillGroupWise)
+        searchFab.visibility = View.GONE
+        return v
     }
 
     @NonNull

--- a/app/src/main/res/layout/fragment_group_wise_skill_listing.xml
+++ b/app/src/main/res/layout/fragment_group_wise_skill_listing.xml
@@ -1,98 +1,118 @@
 <?xml version="1.0" encoding="utf-8"?>
-<android.support.v4.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/swipeRefreshLayout"
-    android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    tools:context="org.fossasia.susi.ai.skills.groupwiseskills.GroupWiseSkillsFragment">
+    xmlns:tools="http://schemas.android.com/tools">
 
-    <FrameLayout
+    <data>
+
+        <variable
+            name="presenter"
+            type="org.fossasia.susi.ai.skills.groupwiseskills.GroupWiseSkillsPresenter" />
+
+        <import type="android.view.View" />
+
+        <variable
+            name="fragment"
+            type="org.fossasia.susi.ai.skills.groupwiseskills.GroupWiseSkillsFragment" />
+
+    </data>
+
+    <android.support.v4.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefreshLayout"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:background="@color/default_bg">
+        android:layout_height="wrap_content"
+        app:refreshing="@{presenter.swipeRefreshController}"
+        tools:context="org.fossasia.susi.ai.skills.groupwiseskills.GroupWiseSkillsFragment">
 
-        <android.support.v7.widget.RecyclerView
-            android:id="@+id/groupWiseSkills"
+        <FrameLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:scrollbars="vertical" />
+            android:background="@color/default_bg">
 
-        <com.facebook.shimmer.ShimmerFrameLayout
-            android:id="@+id/groupWiseSkillsShimmerContainer"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
+            <android.support.v7.widget.RecyclerView
+                android:id="@+id/groupWiseSkills"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:scrollbars="vertical" />
 
-            <LinearLayout
+            <com.facebook.shimmer.ShimmerFrameLayout
+                android:id="@+id/groupWiseSkillsShimmerContainer"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="@{presenter.shimmerController?View.VISIBLE:View.GONE}">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+                    <!-- & rows of shimmer added-->
+                    <include layout="@layout/groupwise_skill_listing_placeholder" />
+
+                    <include layout="@layout/groupwise_skill_listing_placeholder" />
+
+                    <include layout="@layout/groupwise_skill_listing_placeholder" />
+
+                    <include layout="@layout/groupwise_skill_listing_placeholder" />
+
+                    <include layout="@layout/groupwise_skill_listing_placeholder" />
+
+                    <include layout="@layout/groupwise_skill_listing_placeholder" />
+
+                    <include layout="@layout/groupwise_skill_listing_placeholder" />
+
+                </LinearLayout>
+
+            </com.facebook.shimmer.ShimmerFrameLayout>
+
+            <android.support.design.widget.FloatingActionButton
+                android:id="@+id/searchSkillGroupWise"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="@drawable/ic_open_search"
+                android:layout_gravity="right"
+                android:layout_margin="@dimen/margin_moderate"
+                app:backgroundTint="@color/md_white_1000"
+                app:fabSize="mini"
+                app:srcCompat="@drawable/ic_open_search" />
+
+            <EditText
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
-                <!-- & rows of shimmer added-->
-                <include layout="@layout/groupwise_skill_listing_placeholder" />
+                android:layout_marginRight="@dimen/margin_extremely_large"
+                android:layout_gravity="left"
+                android:layout_marginTop="@dimen/margin_small"
+                android:layout_marginLeft="@dimen/margin_small"
+                android:padding="@dimen/padding_moderate"
+                android:imeOptions="actionSearch"
+                android:background="@color/browser_actions_bg_grey"
+                android:singleLine="true"
+                android:visibility="@{fragment.isSearching()?View.VISIBLE:View.GONE}"
+                android:id="@+id/skillWiseSearchEdit" />
 
-                <include layout="@layout/groupwise_skill_listing_placeholder" />
+            <TextView
+                android:id="@+id/errorSkillFetch"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="center_horizontal"
+                android:padding="@dimen/padding_large"
+                android:text="@string/error_skill_listing"
+                android:textColor="@color/colorPrimary"
+                android:textSize="@dimen/text_size_large"
+                android:visibility="gone" />
 
-                <include layout="@layout/groupwise_skill_listing_placeholder" />
-
-                <include layout="@layout/groupwise_skill_listing_placeholder" />
-
-                <include layout="@layout/groupwise_skill_listing_placeholder" />
-
-                <include layout="@layout/groupwise_skill_listing_placeholder" />
-
-                <include layout="@layout/groupwise_skill_listing_placeholder" />
-
-            </LinearLayout>
-
-        </com.facebook.shimmer.ShimmerFrameLayout>
-      
-        <android.support.design.widget.FloatingActionButton
-            android:id="@+id/searchSkillGroupWise"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:background="@drawable/ic_open_search"
-            android:layout_gravity="right"
-            android:layout_margin="@dimen/margin_moderate"
-            android:visibility="gone"
-            app:backgroundTint="@color/md_white_1000"
-            app:fabSize="mini"
-            app:srcCompat="@drawable/ic_open_search" />
-
-        <EditText
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="@dimen/margin_extremely_large"
-            android:layout_gravity="left"
-            android:layout_marginTop="@dimen/margin_small"
-            android:layout_marginLeft="@dimen/margin_small"
-            android:padding="@dimen/padding_moderate"
-            android:background="@color/browser_actions_bg_grey"
-            android:visibility="gone"
-            android:id="@+id/skillWiseSearchEdit" />
-
-        <TextView
-            android:id="@+id/errorSkillFetch"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center_horizontal"
-            android:padding="@dimen/padding_large"
-            android:text="@string/error_skill_listing"
-            android:textColor="@color/colorPrimary"
-            android:textSize="@dimen/text_size_large"
-            android:visibility="gone" />
-
-        <TextView
-            android:id="@+id/messageNoSkillsFound"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center"
-            android:gravity="center_horizontal"
-            android:padding="@dimen/padding_large"
-            android:text="@string/message_no_skills_found"
-            android:textColor="@color/colorPrimary"
-            android:textSize="@dimen/text_size_large"
-            android:visibility="gone" />
-    </FrameLayout>
-</android.support.v4.widget.SwipeRefreshLayout>
+            <TextView
+                android:id="@+id/messageNoSkillsFound"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:gravity="center_horizontal"
+                android:padding="@dimen/padding_large"
+                android:text="@string/message_no_skills_found"
+                android:textColor="@color/colorPrimary"
+                android:textSize="@dimen/text_size_large"
+                android:visibility="gone" />
+        </FrameLayout>
+    </android.support.v4.widget.SwipeRefreshLayout>
+</layout>


### PR DESCRIPTION
First steps for issues #2467 , #2470 

Changes: 
- New object ListHelper which will help in filtering list according to filter
- Gradle for databinding
- SkillActivity for handle clicks on arrow
- GroupWiseSkillsFragment
    - Connected binding
    - Observing livedata for shimmer(shimmerController) and swipe(swipeController)(just observing)
    - converted isSearching to _isSearching (Live data)
    - added revertList method
- GroupWiseSkillPresenter
    - added shimmerController and swipeRefreshController which are observed from fragment
- SearchSkillFragment(also a bug)
    - Set searchtext visibility to gone because no methods are provided to handle search there
- fragment_group_wise_skill_listing
    - added databinding
    - directly observing visibility of shimmer and swipe form presenter

Screenshots for the change: 
before 
![prgif](https://user-images.githubusercontent.com/46514947/73185494-038beb80-40d3-11ea-99cd-759020d11a1c.gif)
after
![issuegif](https://user-images.githubusercontent.com/46514947/73185517-0edf1700-40d3-11ea-89b1-4a2c954d5140.gif)
