### PR TITLE
fix: Added unit test for datahelper class

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/helper/DateTimeHelper.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/helper/DateTimeHelper.kt
@@ -39,6 +39,11 @@ object DateTimeHelper {
             return sdf.format(Date())
         }
 
+    val today: Date
+        get() {
+            return Calendar.getInstance().time
+        }
+
     /**
      * Method to format date from server
 
@@ -46,7 +51,7 @@ object DateTimeHelper {
      * *
      * @return Date
      */
-    private fun formatDate(date: String): Date? {
+    private fun formatDate(date: String): Date {
         val sdf = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
         sdf.timeZone = TimeZone.getTimeZone("UTC")
         var dateIn: Date?
@@ -54,7 +59,7 @@ object DateTimeHelper {
             sdf.parse(date)
         } catch (e: Exception) {
             Timber.e(e)
-            null
+            today
         }
 
         return dateIn
@@ -85,6 +90,25 @@ object DateTimeHelper {
         val sdf = SimpleDateFormat("hh:mm aaa")
         val tz = TimeZone.getDefault()
         sdf.timeZone = tz
-        return sdf.format(formatDate(date))
+        return if (date.isEmpty()) {
+            throw IllegalArgumentException("date argument is empty")
+        } else {
+            sdf.format(formatDate(date))
+        }
+    }
+
+    fun formatDate(timestamp: String, months: Array<String>): String {
+        return if (timestamp.length > 10 && months.size == 12) {
+            var date: String? = ""
+            timestamp.trim()
+            val month = timestamp.substring(5, 7).toInt()
+            date = timestamp.substring(8, 10) + " " +
+                    months[month - 1].toString() +
+                    ", " + timestamp.substring(0, 4)
+
+            date
+        } else {
+            throw IllegalArgumentException("Timestamp or Months format not correct")
+        }
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/feedback/adapters/recycleradapters/AllReviewsAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/feedback/adapters/recycleradapters/AllReviewsAdapter.kt
@@ -7,6 +7,7 @@ import android.text.TextUtils
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import org.fossasia.susi.ai.R
+import org.fossasia.susi.ai.helper.DateTimeHelper
 import org.fossasia.susi.ai.helper.Utils
 import org.fossasia.susi.ai.rest.responses.susi.Feedback
 import org.fossasia.susi.ai.skills.feedback.adapters.viewholders.AllReviewsViewHolder
@@ -19,7 +20,7 @@ class AllReviewsAdapter(
     val context: Context,
     private val feedbackList: List<Feedback>?
 ) :
-    RecyclerView.Adapter<AllReviewsViewHolder>() {
+        RecyclerView.Adapter<AllReviewsViewHolder>() {
 
     @NonNull
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): AllReviewsViewHolder {
@@ -46,7 +47,7 @@ class AllReviewsAdapter(
                 }
                 if (feedbackList[position].timestamp != null &&
                         !TextUtils.isEmpty(feedbackList[position].timestamp)) {
-                    val date: String? = getDate(feedbackList[position].timestamp)
+                    val date: String? = DateTimeHelper.formatDate(feedbackList[position].timestamp as String, context.resources.getStringArray(R.array.months))
                     if (date != null) {
                         holder.feedbackDate.text = date
                     } else {
@@ -59,17 +60,5 @@ class AllReviewsAdapter(
                 }
             }
         }
-    }
-
-    private fun getDate(timestamp: String?): String? {
-        var date: String? = ""
-        if (timestamp != null && !TextUtils.isEmpty(timestamp)) {
-            timestamp.trim()
-            val month = timestamp.substring(5, 7).toInt()
-            date = timestamp.substring(8, 10) + " " +
-                    context.resources.getStringArray(R.array.months)[month - 1].toString() +
-                    ", " + timestamp.substring(0, 4)
-        }
-        return date
     }
 }

--- a/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/skills/skilldetails/adapters/recycleradapters/FeedbackAdapter.kt
@@ -11,6 +11,7 @@ import android.view.View
 import android.view.ViewGroup
 import org.fossasia.susi.ai.R
 import org.fossasia.susi.ai.helper.Constant
+import org.fossasia.susi.ai.helper.DateTimeHelper
 import org.fossasia.susi.ai.helper.PrefManager
 import org.fossasia.susi.ai.helper.Utils
 import org.fossasia.susi.ai.rest.responses.susi.Feedback
@@ -79,7 +80,7 @@ class FeedbackAdapter(
                     }
                     if (arrangedFeedbackList[position].timestamp != null &&
                             !TextUtils.isEmpty(arrangedFeedbackList[position].timestamp)) {
-                        val date: String? = getDate(arrangedFeedbackList[position].timestamp)
+                        val date: String? = DateTimeHelper.formatDate(arrangedFeedbackList[position].timestamp as String, context.resources.getStringArray(R.array.months))
                         if (date != null) {
                             holder.feedbackDate.text = date
                         } else {
@@ -97,18 +98,6 @@ class FeedbackAdapter(
                 holder.seeAllReviews.visibility = View.VISIBLE
             }
         }
-    }
-
-    private fun getDate(timestamp: String?): String? {
-        var date: String? = ""
-        timestamp?.trim()
-        val month = timestamp?.substring(5, 7)?.toInt()
-        if (month != null) {
-            date = timestamp.substring(8, 10) + " " +
-                    context.resources.getStringArray(R.array.months)[month - 1].toString() +
-                    ", " + timestamp.substring(0, 4)
-        }
-        return date
     }
 
     override fun onItemClicked(position: Int) {

--- a/app/src/test/java/org/fossasia/susi/ai/helper/DateTimeHelperTest.kt
+++ b/app/src/test/java/org/fossasia/susi/ai/helper/DateTimeHelperTest.kt
@@ -1,0 +1,71 @@
+package org.fossasia.susi.ai.helper
+
+import java.text.SimpleDateFormat
+import java.util.Calendar
+import java.util.TimeZone
+import junit.framework.TestCase.assertEquals
+import org.junit.Test
+
+class DateTimeHelperTest {
+    private val TIMEZONE_SINGAPORE = "Asia/Singapore"
+    private val TIMEZONE_US_PACIFIC = "US/Pacific"
+    private val TIMEZONE_SYDNEY = "Australia/Sydney"
+    private val TIMEZONE_AMSTERDAM = "Amsterdam"
+    private val TEST_TIME = "2020-01-30T12:18:37.262Z"
+
+    val months = arrayOf("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Aug", "Nov", "Dec")
+    val emptyMonths = arrayOf("")
+
+    @Test
+    fun getDateTest() {
+        val sdf = SimpleDateFormat(" MMM dd, yyyy")
+        assertEquals(sdf.format(Calendar.getInstance().time), DateTimeHelper.getDate(""))
+
+        TimeZone.setDefault(TimeZone.getTimeZone(TIMEZONE_SINGAPORE))
+        assertEquals(" Jan 30, 2020", DateTimeHelper.getDate(TEST_TIME))
+
+        TimeZone.setDefault(TimeZone.getTimeZone(TIMEZONE_US_PACIFIC))
+        assertEquals(" Jan 30, 2020", DateTimeHelper.getDate(TEST_TIME))
+
+        TimeZone.setDefault(TimeZone.getTimeZone(TIMEZONE_SYDNEY))
+        assertEquals(" Jan 30, 2020", DateTimeHelper.getDate(TEST_TIME))
+
+        TimeZone.setDefault(TimeZone.getTimeZone(TIMEZONE_AMSTERDAM))
+        assertEquals(" Jan 30, 2020", DateTimeHelper.getDate(TEST_TIME))
+    }
+
+    @Test
+    fun getTimeTest() {
+        TimeZone.setDefault(TimeZone.getTimeZone(TIMEZONE_SINGAPORE))
+        assertEquals("08:18 PM", DateTimeHelper.getTime(TEST_TIME))
+
+        TimeZone.setDefault(TimeZone.getTimeZone(TIMEZONE_US_PACIFIC))
+        assertEquals("04:18 AM", DateTimeHelper.getTime(TEST_TIME))
+
+        TimeZone.setDefault(TimeZone.getTimeZone(TIMEZONE_SYDNEY))
+        assertEquals("11:18 PM", DateTimeHelper.getTime(TEST_TIME))
+
+        TimeZone.setDefault(TimeZone.getTimeZone(TIMEZONE_AMSTERDAM))
+        assertEquals("12:18 PM", DateTimeHelper.getTime(TEST_TIME))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testEmptyDate_in_getTime() {
+        DateTimeHelper.getTime("")
+    }
+
+    @Test
+    fun formatDateTest() {
+        assertEquals("30 Jan, 2020", DateTimeHelper.formatDate(TEST_TIME, months))
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testEmptyTimestamp_in_formatDateTest() {
+        DateTimeHelper.formatDate("", months)
+    }
+
+    @Test(expected = IllegalArgumentException::class)
+    fun testEmptyMonths_in_formatDateTest() {
+        DateTimeHelper.formatDate("", emptyMonths)
+    }
+}


### PR DESCRIPTION
Fixes #2100 

Changes: Made feedback activity testable and added unit test, since only testable unit in Feedback activity is format date. So migrated getDate() function to DateTimeHelper and added unit test for all other functions of DateTimeHelper

Screenshots for the change: 
![Screenshot (8)](https://user-images.githubusercontent.com/46514947/73598840-e2236900-44f1-11ea-8463-ed95f9051d3b.png)




