### PR TITLE
Fix : Speech to text button on chat activity not working #2469

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
@@ -116,14 +116,7 @@ class STTFragment : Fragment() {
                     speechProgress.onResultOrOnError()
                 val thisActivity = activity
                 if (thisActivity is ChatActivity) thisActivity.setText(voiceResults[0])
-                recognizer.destroy()
-                if ((activity as ChatActivity).recordingThread != null) {
-                    chatPresenter.startHotwordDetection()
-                }
-                (activity as ChatActivity).fabsetting.show()
-                activity?.searchChat?.show()
-                activity?.voiceSearchChat?.show()
-                activity?.btnSpeak?.isEnabled = true
+                restoreActivityState()
                 activity?.supportFragmentManager?.popBackStackImmediate()
             }
 
@@ -175,6 +168,18 @@ class STTFragment : Fragment() {
         recognizer.startListening(intent)
     }
 
+    private fun restoreActivityState() {
+        if ((activity as ChatActivity).recordingThread != null) {
+            chatPresenter.startHotwordDetection()
+        }
+        (activity as ChatActivity).fabsetting.show()
+        activity?.searchChat?.show()
+        activity?.voiceSearchChat?.show()
+        activity?.btnSpeak?.isEnabled = true
+        activity?.chatSearchInput?.visibility = View.GONE
+        recognizer?.destroy()
+    }
+
     override fun onPause() {
         super.onPause()
         if (thisActivity is ChatActivity) {
@@ -190,6 +195,8 @@ class STTFragment : Fragment() {
 
     override fun onDestroyView() {
         super.onDestroyView()
+        restoreActivityState()
+        activity?.supportFragmentManager?.popBackStack()
         mainHandler.removeCallbacks(runnable)
         subHandler.removeCallbacks(delayRunnable)
     }


### PR DESCRIPTION
Fixes #2479 : Speech to text button on chat activity not working

Changes: In the STTfragment.kt, a function : restoreActivityState() was added to make the incisible views visible again

Screenshots for the change: 
![WhatsApp Image 2020-02-05 at 5 08 15 PM(1)](https://user-images.githubusercontent.com/40279181/73838677-3f912000-483a-11ea-8c6b-9d8463c0f631.jpeg)
![WhatsApp Image 2020-02-05 at 5 08 15 PM](https://user-images.githubusercontent.com/40279181/73838681-415ae380-483a-11ea-9494-b9535b30962c.jpeg)

Device : Redmi Note 4
Android : Nougat