### PR TITLE
fix: Speech to text button on chat activity not working #2469

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
@@ -170,7 +170,6 @@ class STTFragment : Fragment() {
         recognizer.startListening(intent)
     }
     private fun restoreActivityState() {
-
         if ((activity as ChatActivity).recordingThread != null) {
             chatPresenter.startHotwordDetection()
         }

--- a/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
@@ -169,7 +169,17 @@ class STTFragment : Fragment() {
         recognizer.setRecognitionListener(listener)
         recognizer.startListening(intent)
     }
+    private fun restoreActivityState() {
 
+        if ((activity as ChatActivity).recordingThread != null) {
+            chatPresenter.startHotwordDetection()
+        }
+        (activity as ChatActivity).fabsetting.show()
+        activity?.searchChat?.show()
+        activity?.voiceSearchChat?.show()
+        activity?.btnSpeak?.isEnabled = true
+        activity?.chatSearchInput?.visibility = View.GONE
+    }
     override fun onPause() {
         super.onPause()
         if (thisActivity is ChatActivity) {


### PR DESCRIPTION
Fixes #2469 Speech to text button on chat activity not working

Changes: Add function restoreActivityState() to make invisible views visible