### PR TITLE
fixed #2469 Speech to text button on chat activity not working

### DIFF
--- a/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
+++ b/app/src/main/java/org/fossasia/susi/ai/chat/STTfragment.kt
@@ -170,6 +170,17 @@ class STTFragment : Fragment() {
         recognizer.startListening(intent)
     }
 
+   private fun restoreActivityState() {
+
+    if ((activity as ChatActivity).recordingThread != null) {
+        chatPresenter.startHotwordDetection()
+    }
+    (activity as ChatActivity).fabsetting.show()
+    activity?.searchChat?.show()
+    activity?.voiceSearchChat?.show()
+    activity?.btnSpeak?.isEnabled = true
+    activity?.chatSearchInput?.visibility = View.GONE
+}
     override fun onPause() {
         super.onPause()
         if (thisActivity is ChatActivity) {


### PR DESCRIPTION
Fixes #2469 

Changes: [Add here what changes were made in this issue and if possible provide links.]
 created private fun restoreActivityState() function at STTfragment.kt class.
Short Video for the change: 

https://user-images.githubusercontent.com/72181295/106854258-00add880-66e1-11eb-8c46-eb0f2ec9bac3.mp4


