### PR TITLE
Fixed the error of gradle.properties "set android.useAndroidX' = true"

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,5 @@
  org.gradle.parallel=true
 
  org.gradle.configureondemand=false
+
+ android.useAndroidX=true


### PR DESCRIPTION
gradle.properties  giving an error of android.useAndroidX' property is not enabled.

Fixes #2586

Changes: [add android.useAndroidX=true in gradle.properties]

Screenshots for the change: 

After Change
![After Change](https://user-images.githubusercontent.com/74103314/122138411-4daa7400-ce64-11eb-9246-7334a0a9bc18.png)


Before Change
![Before Change](https://user-images.githubusercontent.com/74103314/122138415-513dfb00-ce64-11eb-9a03-a3462f93ba2e.png)
